### PR TITLE
Add Text Fill Assistant Chrome extension

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=sk-your-key-here

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# text-fill
-fill the text field based on my resume and current page job description
+# Text Fill Assistant
+
+Chrome extension that drafts job application answers using your resume and the current page's job description.
+
+## Setup
+
+1. **Create an OpenAI key** and keep it ready.
+2. **Load the extension**:
+   - Open `chrome://extensions`.
+   - Enable **Developer mode**.
+   - Click **Load unpacked** and select this repo.
+3. **Open settings**:
+   - Click the extension icon.
+   - Choose **Open Settings**.
+   - Paste your API key and upload or paste your resume text.
+
+## Usage
+
+1. Navigate to a job application page.
+2. Click inside a text area or text input.
+3. Use **Fill with AI** to generate a response.
+4. Click **Insert** to place the answer in the field.
+
+## Notes
+
+- The extension reads the surrounding page content as job description context.
+- Em dashes are normalized to commas.
+- The `.env.example` file is provided to document configuration, but the extension reads the API key from local extension storage after you save it in Settings.

--- a/background.js
+++ b/background.js
@@ -1,0 +1,98 @@
+const OPENAI_ENDPOINT = "https://api.openai.com/v1/chat/completions";
+
+const normalizeAnswer = (text) => {
+  return text
+    .replace(/[—–]/g, ",")
+    .replace(/\s+,/g, ",")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+};
+
+const buildPrompt = ({ resumeText, jobDescription, question, fieldValue }) => {
+  const system = [
+    "You are a writing assistant for job applications.",
+    "Write concise, professional, human-sounding answers with specific details.",
+    "Use plain punctuation only. Never use em dashes.",
+    "Avoid generic AI phrasing and filler.",
+    "Keep the response focused and personalized to the job description and resume.",
+  ].join(" ");
+
+  const user = [
+    "Resume:\n" + (resumeText || "(none provided)"),
+    "\nJob description context:\n" + jobDescription,
+    "\nQuestion or prompt:\n" + question,
+    "\nCurrent field value (if any):\n" + (fieldValue || "(empty)"),
+    "\nWrite the best possible answer.",
+  ].join("\n\n");
+
+  return { system, user };
+};
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type !== "generateAnswer") {
+    return false;
+  }
+
+  (async () => {
+    try {
+      const { apiKey, resumeText } = await chrome.storage.local.get([
+        "apiKey",
+        "resumeText",
+      ]);
+
+      if (!apiKey) {
+        sendResponse({
+          ok: false,
+          error: "Missing API key. Add it in the extension options.",
+        });
+        return;
+      }
+
+      const { system, user } = buildPrompt({
+        resumeText,
+        jobDescription: message.jobDescription,
+        question: message.question,
+        fieldValue: message.fieldValue,
+      });
+
+      const response = await fetch(OPENAI_ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: "gpt-5-nano",
+          temperature: 0.6,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        sendResponse({
+          ok: false,
+          error: `OpenAI request failed: ${errorText}`,
+        });
+        return;
+      }
+
+      const data = await response.json();
+      const answer = data?.choices?.[0]?.message?.content?.trim();
+
+      if (!answer) {
+        sendResponse({ ok: false, error: "No answer returned." });
+        return;
+      }
+
+      sendResponse({ ok: true, answer: normalizeAnswer(answer) });
+    } catch (error) {
+      sendResponse({ ok: false, error: error.message });
+    }
+  })();
+
+  return true;
+});

--- a/contentScript.js
+++ b/contentScript.js
@@ -1,0 +1,185 @@
+const MAX_CONTEXT_CHARS = 4000;
+
+const state = {
+  activeField: null,
+  modal: null,
+  button: null,
+};
+
+const extractJobDescription = () => {
+  const main = document.querySelector("main, article") || document.body;
+  const text = (main?.innerText || "").replace(/\s+/g, " ").trim();
+  return text.slice(0, MAX_CONTEXT_CHARS);
+};
+
+const getQuestionText = (field) => {
+  const aria = field.getAttribute("aria-label") || field.getAttribute("aria-labelledby");
+  if (aria) {
+    const labelled = aria
+      .split(" ")
+      .map((id) => document.getElementById(id)?.innerText || "")
+      .join(" ")
+      .trim();
+    if (labelled) {
+      return labelled;
+    }
+  }
+
+  const label = document.querySelector(`label[for="${field.id}"]`);
+  if (label?.innerText) {
+    return label.innerText.trim();
+  }
+
+  if (field.placeholder) {
+    return field.placeholder.trim();
+  }
+
+  const parentText = field.closest("section, form, div")?.innerText || "";
+  return parentText.split("\n").slice(0, 3).join(" ").trim();
+};
+
+const ensureButton = () => {
+  if (state.button) {
+    return state.button;
+  }
+
+  const button = document.createElement("button");
+  button.className = "tfa-floating-button";
+  button.type = "button";
+  button.textContent = "Fill with AI";
+  button.addEventListener("click", openModal);
+  document.body.appendChild(button);
+  state.button = button;
+  return button;
+};
+
+const positionButton = (field) => {
+  const rect = field.getBoundingClientRect();
+  const button = ensureButton();
+  button.style.top = `${window.scrollY + rect.top - 12}px`;
+  button.style.left = `${window.scrollX + rect.right - 120}px`;
+  button.hidden = false;
+};
+
+const closeModal = () => {
+  if (state.modal) {
+    state.modal.remove();
+    state.modal = null;
+  }
+};
+
+const openModal = () => {
+  closeModal();
+  if (!state.activeField) {
+    return;
+  }
+
+  const modal = document.createElement("div");
+  modal.className = "tfa-modal";
+  modal.innerHTML = `
+    <div class="tfa-card">
+      <div class="tfa-header">
+        <div>
+          <h3>Draft answer</h3>
+          <p>Uses your resume and this page's job description.</p>
+        </div>
+        <button class="tfa-close" type="button">Close</button>
+      </div>
+      <div class="tfa-body">
+        <label class="tfa-label">Question</label>
+        <div class="tfa-question"></div>
+        <label class="tfa-label">Answer</label>
+        <textarea class="tfa-output" placeholder="Generate a response..."></textarea>
+        <div class="tfa-error" hidden></div>
+      </div>
+      <div class="tfa-actions">
+        <button class="tfa-secondary" type="button">Generate</button>
+        <button class="tfa-primary" type="button">Insert</button>
+      </div>
+    </div>
+  `;
+
+  modal.querySelector(".tfa-close").addEventListener("click", closeModal);
+  modal.addEventListener("click", (event) => {
+    if (event.target === modal) {
+      closeModal();
+    }
+  });
+
+  const question = getQuestionText(state.activeField) || "Job application response";
+  modal.querySelector(".tfa-question").textContent = question;
+
+  const output = modal.querySelector(".tfa-output");
+  const error = modal.querySelector(".tfa-error");
+  const generateButton = modal.querySelector(".tfa-secondary");
+  const insertButton = modal.querySelector(".tfa-primary");
+
+  generateButton.addEventListener("click", async () => {
+    error.hidden = true;
+    output.value = "";
+    generateButton.disabled = true;
+    generateButton.textContent = "Working...";
+
+    const response = await chrome.runtime.sendMessage({
+      type: "generateAnswer",
+      question,
+      fieldValue: state.activeField.value,
+      jobDescription: extractJobDescription(),
+    });
+
+    generateButton.disabled = false;
+    generateButton.textContent = "Generate";
+
+    if (!response?.ok) {
+      error.hidden = false;
+      error.textContent = response?.error || "Something went wrong.";
+      return;
+    }
+
+    output.value = response.answer;
+  });
+
+  insertButton.addEventListener("click", () => {
+    if (!output.value.trim()) {
+      return;
+    }
+    state.activeField.value = output.value.trim();
+    state.activeField.dispatchEvent(new Event("input", { bubbles: true }));
+    closeModal();
+  });
+
+  document.body.appendChild(modal);
+  state.modal = modal;
+};
+
+const handleFocus = (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLTextAreaElement || target instanceof HTMLInputElement)) {
+    return;
+  }
+  if (target instanceof HTMLInputElement && target.type !== "text") {
+    return;
+  }
+
+  state.activeField = target;
+  positionButton(target);
+};
+
+const handleBlur = () => {
+  if (state.button) {
+    state.button.hidden = true;
+  }
+};
+
+window.addEventListener("focusin", handleFocus);
+window.addEventListener("focusout", handleBlur);
+window.addEventListener("scroll", () => {
+  if (state.activeField) {
+    positionButton(state.activeField);
+  }
+});
+window.addEventListener("resize", () => {
+  if (state.activeField) {
+    positionButton(state.activeField);
+  }
+});

--- a/contentStyles.css
+++ b/contentStyles.css
@@ -1,0 +1,130 @@
+.tfa-floating-button {
+  position: absolute;
+  z-index: 2147483647;
+  background: #0b2f3a;
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 18px;
+  font-size: 12px;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.18);
+}
+
+.tfa-floating-button[hidden] {
+  display: none;
+}
+
+.tfa-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 20, 30, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2147483647;
+  padding: 24px;
+}
+
+.tfa-card {
+  background: #ffffff;
+  border-radius: 16px;
+  width: min(640px, 94vw);
+  box-shadow: 0 16px 40px rgba(15, 20, 30, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+}
+
+.tfa-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.tfa-header h3 {
+  margin: 0;
+  font-size: 18px;
+  color: #0b2f3a;
+}
+
+.tfa-header p {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: #4a5568;
+}
+
+.tfa-close {
+  background: none;
+  border: none;
+  color: #0b2f3a;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.tfa-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tfa-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #4a5568;
+}
+
+.tfa-question {
+  padding: 10px 12px;
+  background: #f5f7fb;
+  border-radius: 10px;
+  font-size: 13px;
+  color: #1a202c;
+}
+
+.tfa-output {
+  width: 100%;
+  min-height: 160px;
+  border-radius: 10px;
+  border: 1px solid #d7dde5;
+  padding: 12px;
+  font-size: 14px;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.tfa-error {
+  background: #fdecea;
+  color: #b42318;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+}
+
+.tfa-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.tfa-secondary,
+.tfa-primary {
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 13px;
+  cursor: pointer;
+  border: none;
+}
+
+.tfa-secondary {
+  background: #edf2f7;
+  color: #1a202c;
+}
+
+.tfa-primary {
+  background: #0b2f3a;
+  color: #ffffff;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,24 @@
+{
+  "manifest_version": 3,
+  "name": "Text Fill Assistant",
+  "version": "0.1.0",
+  "description": "Fill job application text areas using your resume and job description context.",
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Text Fill Assistant"
+  },
+  "options_page": "options.html",
+  "permissions": ["storage", "activeTab"],
+  "host_permissions": ["https://api.openai.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["contentScript.js"],
+      "css": ["contentStyles.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/options.css
+++ b/options.css
@@ -1,0 +1,85 @@
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #f5f7fb;
+  color: #0b2f3a;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 32px 20px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+header h1 {
+  margin: 0 0 4px;
+}
+
+header p {
+  margin: 0;
+  color: #4a5568;
+}
+
+.card {
+  background: #ffffff;
+  padding: 20px;
+  border-radius: 16px;
+  box-shadow: 0 10px 24px rgba(15, 20, 30, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+
+input[type="password"],
+textarea {
+  border-radius: 10px;
+  border: 1px solid #d7dde5;
+  padding: 10px 12px;
+  font-size: 14px;
+  font-family: inherit;
+}
+
+textarea {
+  min-height: 160px;
+  resize: vertical;
+}
+
+button {
+  align-self: flex-start;
+  background: #0b2f3a;
+  color: #ffffff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 16px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.hint {
+  color: #4a5568;
+  font-size: 13px;
+  margin: 0;
+}
+
+#status {
+  margin-left: 12px;
+  font-size: 13px;
+}
+
+#status.success {
+  color: #087443;
+}
+
+#status.error {
+  color: #b42318;
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Text Fill Assistant Settings</title>
+    <link rel="stylesheet" href="options.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header>
+        <h1>Text Fill Assistant</h1>
+        <p>Connect your OpenAI key and upload your resume once.</p>
+      </header>
+
+      <section class="card">
+        <h2>OpenAI API Key</h2>
+        <label>
+          <span>API Key</span>
+          <input type="password" id="apiKey" placeholder="sk-..." />
+        </label>
+      </section>
+
+      <section class="card">
+        <h2>Resume</h2>
+        <p class="hint">Upload a PDF or text file. We store extracted text locally in the extension.</p>
+        <input type="file" id="resumeFile" accept=".pdf,.txt" />
+        <textarea id="resumeText" placeholder="Or paste your resume text here..."></textarea>
+      </section>
+
+      <section class="card">
+        <h2>Save</h2>
+        <button id="save">Save Settings</button>
+        <span id="status"></span>
+      </section>
+    </main>
+
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,54 @@
+const apiKeyInput = document.getElementById("apiKey");
+const resumeFileInput = document.getElementById("resumeFile");
+const resumeTextInput = document.getElementById("resumeText");
+const saveButton = document.getElementById("save");
+const status = document.getElementById("status");
+
+const showStatus = (message, isError = false) => {
+  status.textContent = message;
+  status.className = isError ? "error" : "success";
+  setTimeout(() => {
+    status.textContent = "";
+    status.className = "";
+  }, 3000);
+};
+
+const loadSettings = async () => {
+  const { apiKey, resumeText } = await chrome.storage.local.get([
+    "apiKey",
+    "resumeText",
+  ]);
+  apiKeyInput.value = apiKey || "";
+  resumeTextInput.value = resumeText || "";
+};
+
+resumeFileInput.addEventListener("change", async (event) => {
+  const file = event.target.files?.[0];
+  if (!file) {
+    return;
+  }
+
+  if (file.type === "application/pdf") {
+    showStatus("PDF parsing is not supported yet. Upload a .txt file.", true);
+    resumeFileInput.value = "";
+    return;
+  }
+
+  const text = await file.text();
+  resumeTextInput.value = text.trim();
+});
+
+saveButton.addEventListener("click", async () => {
+  const apiKey = apiKeyInput.value.trim();
+  const resumeText = resumeTextInput.value.trim();
+
+  if (!apiKey) {
+    showStatus("API key is required.", true);
+    return;
+  }
+
+  await chrome.storage.local.set({ apiKey, resumeText });
+  showStatus("Saved.");
+});
+
+loadSettings();

--- a/popup.css
+++ b/popup.css
@@ -1,0 +1,32 @@
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #ffffff;
+}
+
+.popup {
+  width: 260px;
+  padding: 16px;
+  color: #0b2f3a;
+}
+
+h1 {
+  font-size: 16px;
+  margin: 0 0 8px;
+}
+
+p {
+  font-size: 12px;
+  color: #4a5568;
+  margin: 0 0 12px;
+}
+
+button {
+  background: #0b2f3a;
+  color: #ffffff;
+  border: none;
+  border-radius: 10px;
+  padding: 8px 12px;
+  font-size: 12px;
+  cursor: pointer;
+}

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Text Fill Assistant</title>
+    <link rel="stylesheet" href="popup.css" />
+  </head>
+  <body>
+    <div class="popup">
+      <h1>Text Fill Assistant</h1>
+      <p>Click a text area on any job application to generate a response.</p>
+      <button id="openOptions">Open Settings</button>
+    </div>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,3 @@
+document.getElementById("openOptions").addEventListener("click", () => {
+  chrome.runtime.openOptionsPage();
+});


### PR DESCRIPTION
### Motivation
- Provide a Chrome extension that drafts personalized job application answers using the user’s resume and the page job description as context.
- Ensure answers are clean and human-like with punctuation normalization (convert em dashes to commas) and avoidance of generic AI phrasing.
- Store API credentials and resume locally in the extension options to avoid hardcoding secrets.
- Offer a minimal, unobtrusive UI to generate and insert responses directly into text areas.

### Description
- Add `manifest.json` and a background worker `background.js` that builds the prompt, calls the OpenAI `gpt-5-nano` model, and normalizes responses via `normalizeAnswer`.
- Implement `contentScript.js` plus `contentStyles.css` to detect focused text fields, extract nearby page text as job description, show a floating `Fill with AI` button, and display a generation modal UI.
- Add options UI (`options.html`, `options.js`, `options.css`) for saving the OpenAI API key and uploading/pasting resume text, and a popup (`popup.html`, `popup.js`, `popup.css`) to open settings.
- Include `.env.example`, `.gitignore`, and an expanded `README.md` documenting setup and usage.

### Testing
- No automated tests were executed for this change.
- Basic local setup steps are documented in `README.md` for manual verification of extension loading and usage.
- (No CI or unit tests added as part of this PR.)
- Manual interaction required to validate runtime behavior in Chrome.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fd90bb9f08320bf46b78008ce90da)