### PR TITLE
Add social context settings and prompt support; harden getQuestionText

### DIFF
--- a/background.js
+++ b/background.js
@@ -130,6 +130,7 @@ const SOCIAL_STYLE_PROMPTS = {
 
 const buildSocialPrompt = ({
   socialStyle,
+  socialContext,
   pageContext,
   question,
   fieldValue,
@@ -147,6 +148,7 @@ const buildSocialPrompt = ({
   ].join(" ");
 
   const user = [
+    "Social context:\n" + (socialContext || "(none provided)"),
     "Page context:\n" + (pageContext || "(none provided)"),
     "\nField or prompt:\n" + question,
     "\nExisting content (if any):\n" + (fieldValue || "(empty)"),
@@ -361,6 +363,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         socialStyle,
         systemPrompt,
         generalContextText,
+        socialContextText,
         resumeText,
         openaiKey,
         anthropicKey,
@@ -372,6 +375,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         "socialStyle",
         "systemPrompt",
         "generalContextText",
+        "socialContextText",
         "resumeText",
         "openaiKey",
         "anthropicKey",
@@ -416,6 +420,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       if (activeMode === "social") {
         promptPayload = buildSocialPrompt({
           socialStyle: socialStyle || "genz",
+          socialContext: socialContextText,
           pageContext: message.pageContext,
           question: message.question,
           fieldValue: message.fieldValue,

--- a/contentScript.js
+++ b/contentScript.js
@@ -582,17 +582,23 @@ const extractPageContext = (field) => {
 };
 
 const getQuestionText = (field) => {
+  if (!(field instanceof Element)) {
+    return "";
+  }
+
   const ariaLabel = field.getAttribute("aria-label");
   if (ariaLabel) {
     return ariaLabel.trim();
   }
 
   const ariaLabelledBy = field.getAttribute("aria-labelledby");
-  if (ariaLabelledBy) {
+  if (typeof ariaLabelledBy === "string" && ariaLabelledBy.trim()) {
     const labelled = ariaLabelledBy
+      .trim()
       .split(/\s+/)
-      .filter(id => id)
-      .map((id) => document.getElementById(id)?.innerText || "")
+      .map((id) => document.getElementById(id))
+      .filter((element) => element && typeof element.textContent === "string")
+      .map((element) => element.textContent.trim())
       .filter(text => text)
       .join(" ")
       .trim();

--- a/options.html
+++ b/options.html
@@ -205,6 +205,25 @@
             <textarea id="systemPrompt" placeholder="e.g., Write concise replies in a friendly, professional tone." rows="4"></textarea>
           </div>
         </div>
+
+        <div class="tab-panel mode-panel" data-panel="social">
+          <h2>Social Context (Social Mode)</h2>
+          <p class="hint">Upload a PDF or text file, or paste background details to help with social posts and replies.</p>
+          <div class="field">
+            <div class="file-upload" id="socialUploadArea">
+              <input type="file" id="socialFile" accept=".pdf,.txt,.md" />
+              <span id="socialUploadLabel">Drop PDF or text file here, or click to browse</span>
+            </div>
+            <div id="socialFileInfo" class="file-info" style="display: none;">
+              <span id="socialFileName"></span>
+              <button type="button" id="clearSocialFile" class="btn-clear">Clear</button>
+            </div>
+          </div>
+          <div class="field">
+            <label for="socialText">Social Context Text</label>
+            <textarea id="socialText" placeholder="Paste context for social media posts and comments..." rows="8"></textarea>
+          </div>
+        </div>
       </section>
 
       <!-- Save -->

--- a/options.js
+++ b/options.js
@@ -27,6 +27,13 @@ const generalUploadLabel = document.getElementById('generalUploadLabel');
 const generalFileInfo = document.getElementById('generalFileInfo');
 const generalFileName = document.getElementById('generalFileName');
 const clearGeneralFileBtn = document.getElementById('clearGeneralFile');
+const socialFileInput = document.getElementById('socialFile');
+const socialTextInput = document.getElementById('socialText');
+const socialUploadArea = document.getElementById('socialUploadArea');
+const socialUploadLabel = document.getElementById('socialUploadLabel');
+const socialFileInfo = document.getElementById('socialFileInfo');
+const socialFileName = document.getElementById('socialFileName');
+const clearSocialFileBtn = document.getElementById('clearSocialFile');
 const systemPromptInput = document.getElementById('systemPrompt');
 const saveButton = document.getElementById('save');
 const status = document.getElementById('status');
@@ -154,6 +161,8 @@ const loadSettings = async () => {
     'resumeFileName',
     'generalContextText',
     'generalFileName',
+    'socialContextText',
+    'socialFileName',
     'systemPrompt',
   ]);
 
@@ -188,6 +197,7 @@ const loadSettings = async () => {
   geminiKeyInput.value = data.geminiKey || '';
   resumeTextInput.value = data.resumeText || '';
   generalTextInput.value = data.generalContextText || '';
+  socialTextInput.value = data.socialContextText || '';
   systemPromptInput.value = data.systemPrompt || '';
 
   // Show file info if we have a saved file name
@@ -196,6 +206,9 @@ const loadSettings = async () => {
   }
   if (data.generalFileName) {
     showGeneralFileInfo(data.generalFileName);
+  }
+  if (data.socialFileName) {
+    showSocialFileInfo(data.socialFileName);
   }
 
   // Set model selections
@@ -232,6 +245,18 @@ const hideGeneralFileInfo = () => {
   generalFileInput.value = '';
 };
 
+const showSocialFileInfo = (name) => {
+  socialFileInfo.style.display = 'flex';
+  socialFileName.textContent = name;
+  socialUploadArea.style.display = 'none';
+};
+
+const hideSocialFileInfo = () => {
+  socialFileInfo.style.display = 'none';
+  socialUploadArea.style.display = 'flex';
+  socialFileInput.value = '';
+};
+
 // Clear file button
 clearFileBtn.addEventListener('click', () => {
   hideFileInfo();
@@ -245,6 +270,13 @@ clearGeneralFileBtn.addEventListener('click', () => {
   generalTextInput.value = '';
   chrome.storage.local.remove('generalFileName');
   showStatus('General context cleared.');
+});
+
+clearSocialFileBtn.addEventListener('click', () => {
+  hideSocialFileInfo();
+  socialTextInput.value = '';
+  chrome.storage.local.remove('socialFileName');
+  showStatus('Social context cleared.');
 });
 
 // Drag and drop handling
@@ -356,6 +388,21 @@ generalFileInput.addEventListener('change', async (event) => {
   }
 });
 
+socialFileInput.addEventListener('change', async (event) => {
+  const file = event.target.files?.[0];
+  if (file) {
+    await handleFileUpload({
+      file,
+      uploadLabelElement: socialUploadLabel,
+      textInput: socialTextInput,
+      showInfo: showSocialFileInfo,
+      fileNameKey: 'socialFileName',
+      maxChars: MAX_RESUME_CHARS,
+      successLabel: 'Social context',
+    });
+  }
+});
+
 setupDragAndDrop(fileUploadArea, async (file) => {
   await handleFileUpload({
     file,
@@ -380,6 +427,18 @@ setupDragAndDrop(generalUploadArea, async (file) => {
   });
 });
 
+setupDragAndDrop(socialUploadArea, async (file) => {
+  await handleFileUpload({
+    file,
+    uploadLabelElement: socialUploadLabel,
+    textInput: socialTextInput,
+    showInfo: showSocialFileInfo,
+    fileNameKey: 'socialFileName',
+    maxChars: MAX_RESUME_CHARS,
+    successLabel: 'Social context',
+  });
+});
+
 // Save settings
 saveButton.addEventListener('click', async () => {
   const openaiKey = openaiKeyInput.value.trim();
@@ -387,6 +446,7 @@ saveButton.addEventListener('click', async () => {
   const geminiKey = geminiKeyInput.value.trim();
   const resumeText = sanitizeText(resumeTextInput.value, MAX_RESUME_CHARS);
   const generalContextText = sanitizeText(generalTextInput.value, MAX_RESUME_CHARS);
+  const socialContextText = sanitizeText(socialTextInput.value, MAX_RESUME_CHARS);
   const systemPrompt = sanitizeText(systemPromptInput.value, MAX_RESUME_CHARS);
 
   // Get the model for the active provider
@@ -415,6 +475,7 @@ saveButton.addEventListener('click', async () => {
     geminiKey,
     resumeText,
     generalContextText,
+    socialContextText,
     systemPrompt,
   });
 


### PR DESCRIPTION
### Motivation
- Provide a dedicated Social-mode context input (file upload + textarea) so social prompts can use background details similar to Job/General modes.
- Keep social prompt usage optional and minimally change existing Social prompt structure.
- Persist social context and uploaded filenames to storage so settings round-trip works like other contexts.
- Prevent runtime errors and incorrect label extraction when `getQuestionText` is called with non-DOM values or malformed `aria-labelledby` attributes.

### Description
- Add a Social Context panel to `options.html` with file upload, filename display, clear control, and a `textarea` (`#socialFile`, `#socialText`).
- Wire social inputs into `options.js` by adding DOM refs, load/save of `socialContextText` and `socialFileName`, drag/drop and file handlers, show/hide/clear helpers, and include `socialContextText` in the storage `set`/`get` calls.
- Update `background.js` to read `socialContextText` from storage and pass it to `buildSocialPrompt`, and include a `Social context:` block inside the assembled user prompt.
- Harden `getQuestionText` in `contentScript.js` to return early when `field` is not an `Element` and to safely resolve `aria-labelledby` IDs using `document.getElementById` and `textContent.trim()` while filtering invalid references.

### Testing
- No automated unit tests were run for these changes.
- A Playwright attempt to render `options.html` for a screenshot failed due to a file load error in the container (`ERR_FILE_NOT_FOUND`).
- Manual code inspection and local runtime checks were performed during development (no automated results recorded).
- All modified files updated: `options.html`, `options.js`, `background.js`, and `contentScript.js` and were committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ce3335048320822af3645106f0ba)