### PR TITLE
feat: agent architecture overhaul — plan+execute, cancellation, and UI

### DIFF
--- a/cheat-resume-backend
+++ b/cheat-resume-backend
@@ -11,6 +11,34 @@ TARGET_PIDS=()
 TEMPORAL_PID=""
 TEMPORAL_STARTED_BY_LAUNCHER="0"
 
+python_supports_mcp_agent() {
+  local python_bin="${1:-}"
+  [[ -n "$python_bin" ]] || return 1
+  "$python_bin" - <<'PY' >/dev/null 2>&1
+import sys
+raise SystemExit(0 if sys.version_info >= (3, 10) else 1)
+PY
+}
+
+resolve_python_bin() {
+  if [[ -n "${LOCAL_COMPANION_PYTHON:-}" ]]; then
+    command -v "$LOCAL_COMPANION_PYTHON"
+    return $?
+  fi
+
+  local candidate=""
+  for candidate in python3.12 python3.13 python3.11 python3.10 python3; do
+    if command -v "$candidate" >/dev/null 2>&1 && python_supports_mcp_agent "$candidate"; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+
+  command -v python3 2>/dev/null || true
+}
+
+PYTHON_BIN="$(resolve_python_bin)"
+
 show_help() {
   cat <<'EOF'
 Usage:
@@ -68,7 +96,7 @@ is_port_listening() {
     return $?
   fi
 
-  python3 - "$host" "$port" <<'PY' >/dev/null 2>&1
+    "$PYTHON_BIN" - "$host" "$port" <<'PY' >/dev/null 2>&1
 import socket
 import sys
 
@@ -138,7 +166,7 @@ ensure_temporal_server() {
     LOCAL_COMPANION_TEMPORAL_UI="${LOCAL_COMPANION_TEMPORAL_UI:-0}" \
     LOCAL_COMPANION_TEMPORAL_UI_PORT="${LOCAL_COMPANION_TEMPORAL_UI_PORT:-8233}" \
     LOCAL_COMPANION_TEMPORAL_LOG_LEVEL="${LOCAL_COMPANION_TEMPORAL_LOG_LEVEL:-warn}" \
-    python3 -m uv run --with temporalio python companion/temporal_dev_server.py &
+    "$PYTHON_BIN" -m uv run --with temporalio python companion/temporal_dev_server.py &
   TEMPORAL_PID="$!"
   TEMPORAL_STARTED_BY_LAUNCHER="1"
   echo "$TEMPORAL_PID" > "$temporal_pid_file"
@@ -374,8 +402,15 @@ if ! command -v node >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
+if [[ -z "$PYTHON_BIN" ]]; then
   echo "Error: Python 3 is required for the mcp-agent bridge runtime." >&2
+  exit 1
+fi
+
+if ! python_supports_mcp_agent "$PYTHON_BIN"; then
+  echo "Error: Python 3.10+ is required for the mcp-agent bridge runtime." >&2
+  echo "Detected: $("$PYTHON_BIN" --version 2>&1)" >&2
+  echo "Install a newer Python, or set LOCAL_COMPANION_PYTHON=/path/to/python3.12." >&2
   exit 1
 fi
 
@@ -384,10 +419,10 @@ if ! command -v npm >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! python3 -m uv --version >/dev/null 2>&1; then
+if ! "$PYTHON_BIN" -m uv --version >/dev/null 2>&1; then
   echo "Installing uv for the mcp-agent bridge runtime..."
-  if ! python3 -m pip install --user uv; then
-    python3 -m pip install --user --break-system-packages uv
+  if ! "$PYTHON_BIN" -m pip install --user uv; then
+    "$PYTHON_BIN" -m pip install --user --break-system-packages uv
   fi
 fi
 
@@ -421,4 +456,6 @@ env \
   LOCAL_COMPANION_TEMPORAL_NAMESPACE="$TEMPORAL_NAMESPACE" \
   LOCAL_COMPANION_TEMPORAL_TASK_QUEUE="$TEMPORAL_TASK_QUEUE" \
   LOCAL_COMPANION_TEMPORAL_PID_FILE="$TEMPORAL_PID_FILE" \
+  MCP_AGENT_BRIDGE_COMMAND="$PYTHON_BIN" \
+  MCP_AGENT_PYTHON_RUNTIME_COMMAND="$PYTHON_BIN" \
   npm run companion:dev

--- a/companion/chrome-devtools-mcp-runtime.ts
+++ b/companion/chrome-devtools-mcp-runtime.ts
@@ -275,14 +275,6 @@ export class ChromeDevtoolsMcpRuntime {
     }
   }
 
-  supportsManagedTaskRetries(): boolean {
-    return true;
-  }
-
-  supportsManagedTaskWorkflows(): boolean {
-    return true;
-  }
-
   async insertDraft(args: {
     pageUrl: string;
     fieldTarget: LocalCompanionFieldTarget;
@@ -378,6 +370,7 @@ export class ChromeDevtoolsMcpRuntime {
   async executeAgentTask(args: {
     providerConfig: LocalCompanionProviderConfig;
     goal: string;
+    runId?: string;
     pageUrl?: string;
     platformHint?: string;
     pageContext?: string;
@@ -389,12 +382,35 @@ export class ChromeDevtoolsMcpRuntime {
     structured?: LocalCompanionStructuredExtraction | null;
     scannedCandidates?: LocalCompanionCandidateScanItem[];
     resumeFile?: ResumeFileData | null;
-  }): Promise<{
+  }, signal?: AbortSignal): Promise<{
     summary: string;
     metadata: Record<string, unknown>;
   }> {
     const pythonBridge = await this.getRequiredPythonBridge();
-    return pythonBridge.executeAgentTask(args);
+    return pythonBridge.executeAgentTask(args, signal);
+  }
+
+  killPythonBridge(): void {
+    if (!this.pythonBridgePromise) return;
+    void this.pythonBridgePromise
+      .then((bridge) => bridge.close())
+      .catch(() => undefined);
+    this.pythonBridgePromise = null;
+    this.lastHealthCheck = null;
+  }
+
+  async registerProgressHandler(
+    runId: string,
+    callback: (event: Record<string, unknown>) => void
+  ): Promise<void> {
+    const pythonBridge = await this.getPythonBridge().catch(() => null);
+    pythonBridge?.registerProgressHandler(runId, callback);
+  }
+
+  unregisterProgressHandler(runId: string): void {
+    void this.getPythonBridge().then((bridge) => {
+      bridge?.unregisterProgressHandler(runId);
+    }).catch(() => undefined);
   }
 
   async deriveBrowserWorkItems(args: {
@@ -418,90 +434,6 @@ export class ChromeDevtoolsMcpRuntime {
   }> {
     const pythonBridge = await this.getRequiredPythonBridge();
     return pythonBridge.deriveBrowserWorkItems(args);
-  }
-
-  async startAgentTaskWorkflow(args: {
-    providerConfig: LocalCompanionProviderConfig;
-    goal: string;
-    pageUrl?: string;
-    platformHint?: string;
-    pageContext?: string;
-    resumeContext?: string;
-    siteExperienceContext?: string;
-    userContext?: string;
-    systemPrompt?: string;
-    fieldTarget?: LocalCompanionFieldTarget;
-    structured?: LocalCompanionStructuredExtraction | null;
-    scannedCandidates?: LocalCompanionCandidateScanItem[];
-    workItems?: LocalCompanionBrowserWorkItem[];
-    resumeFile?: ResumeFileData | null;
-  }): Promise<{
-    workflowId: string;
-    runId?: string;
-  }> {
-    const pythonBridge = await this.getRequiredPythonBridge();
-    return pythonBridge.startGenericBrowserTaskWorkflow(args);
-  }
-
-  async startGenericBrowserQueueWorkflow(args: {
-    providerConfig: LocalCompanionProviderConfig;
-    goal: string;
-    pageUrl?: string;
-    platformHint?: string;
-    pageContext?: string;
-    resumeContext?: string;
-    siteExperienceContext?: string;
-    userContext?: string;
-    systemPrompt?: string;
-    fieldTarget?: LocalCompanionFieldTarget;
-    structured?: LocalCompanionStructuredExtraction | null;
-    scannedCandidates?: LocalCompanionCandidateScanItem[];
-    workItems: LocalCompanionBrowserWorkItem[];
-    resumeFile?: ResumeFileData | null;
-  }): Promise<{
-    workflowId: string;
-    runId?: string;
-  }> {
-    const pythonBridge = await this.getRequiredPythonBridge();
-    return pythonBridge.startGenericBrowserQueueWorkflow(args);
-  }
-
-  async startLinkedInConnectBatchWorkflow(args: {
-    items: LinkedInBatchItem[];
-    dailyLimit: number;
-    providerConfig: LocalCompanionProviderConfig;
-  }): Promise<{
-    workflowId: string;
-    runId?: string;
-  }> {
-    const pythonBridge = await this.getRequiredPythonBridge();
-    return pythonBridge.startLinkedInConnectBatchWorkflow(args);
-  }
-
-  async getAgentTaskWorkflowStatus(args: {
-    workflowId?: string;
-    runId?: string;
-  }): Promise<Record<string, unknown> | null> {
-    const pythonBridge = await this.getRequiredPythonBridge();
-    return pythonBridge.getWorkflowStatus(args);
-  }
-
-  async resumeAgentTaskWorkflow(args: {
-    workflowId?: string;
-    runId?: string;
-    signalName?: string;
-    payload?: unknown;
-  }): Promise<boolean> {
-    const pythonBridge = await this.getRequiredPythonBridge();
-    return pythonBridge.resumeWorkflow(args);
-  }
-
-  async cancelAgentTaskWorkflow(args: {
-    workflowId?: string;
-    runId?: string;
-  }): Promise<boolean> {
-    const pythonBridge = await this.getRequiredPythonBridge();
-    return pythonBridge.cancelWorkflow(args);
   }
 
   async dispose(): Promise<void> {

--- a/companion/python-browser-runtime-bridge.ts
+++ b/companion/python-browser-runtime-bridge.ts
@@ -14,12 +14,6 @@ type ConsoleLike = Pick<typeof console, "log" | "warn" | "error">;
 type BridgeMethod =
   | "health"
   | "derive_browser_work_items"
-  | "start_generic_browser_task_workflow"
-  | "start_generic_browser_queue_workflow"
-  | "start_linkedin_connect_batch_workflow"
-  | "get_workflow_status"
-  | "resume_workflow"
-  | "cancel_workflow"
   | "navigate_to_url"
   | "insert_draft"
   | "execute_linkedin_connect_batch"
@@ -73,66 +67,6 @@ export interface PythonBrowserRuntimeConnection {
     summary: string;
     workItems: LocalCompanionBrowserWorkItem[];
   }>;
-  startGenericBrowserTaskWorkflow(args: {
-    providerConfig: LocalCompanionProviderConfig;
-    goal: string;
-    pageUrl?: string;
-    platformHint?: string;
-    pageContext?: string;
-    resumeContext?: string;
-    siteExperienceContext?: string;
-    userContext?: string;
-    systemPrompt?: string;
-    fieldTarget?: LocalCompanionFieldTarget;
-    structured?: LocalCompanionStructuredExtraction | null;
-    scannedCandidates?: LocalCompanionCandidateScanItem[];
-    workItems?: LocalCompanionBrowserWorkItem[];
-    resumeFile?: ResumeFileData | null;
-  }): Promise<{
-    workflowId: string;
-    runId?: string;
-  }>;
-  startGenericBrowserQueueWorkflow(args: {
-    providerConfig: LocalCompanionProviderConfig;
-    goal: string;
-    pageUrl?: string;
-    platformHint?: string;
-    pageContext?: string;
-    resumeContext?: string;
-    siteExperienceContext?: string;
-    userContext?: string;
-    systemPrompt?: string;
-    fieldTarget?: LocalCompanionFieldTarget;
-    structured?: LocalCompanionStructuredExtraction | null;
-    scannedCandidates?: LocalCompanionCandidateScanItem[];
-    workItems: LocalCompanionBrowserWorkItem[];
-    resumeFile?: ResumeFileData | null;
-  }): Promise<{
-    workflowId: string;
-    runId?: string;
-  }>;
-  startLinkedInConnectBatchWorkflow(args: {
-    items: Array<{ targetUrl: string; targetName?: string; generatedText?: string }>;
-    dailyLimit: number;
-    providerConfig: LocalCompanionProviderConfig;
-  }): Promise<{
-    workflowId: string;
-    runId?: string;
-  }>;
-  getWorkflowStatus(args: {
-    workflowId?: string;
-    runId?: string;
-  }): Promise<Record<string, unknown> | null>;
-  resumeWorkflow(args: {
-    workflowId?: string;
-    runId?: string;
-    signalName?: string;
-    payload?: unknown;
-  }): Promise<boolean>;
-  cancelWorkflow(args: {
-    workflowId?: string;
-    runId?: string;
-  }): Promise<boolean>;
   navigateToUrl(args: {
     targetUrl: string;
     currentPageUrl?: string;
@@ -160,9 +94,10 @@ export interface PythonBrowserRuntimeConnection {
     summary: string;
     metadata: Record<string, unknown>;
   }>;
-    executeAgentTask(args: {
+  executeAgentTask(args: {
     providerConfig: LocalCompanionProviderConfig;
     goal: string;
+    runId?: string;
     pageUrl?: string;
     platformHint?: string;
     pageContext?: string;
@@ -175,10 +110,12 @@ export interface PythonBrowserRuntimeConnection {
     scannedCandidates?: LocalCompanionCandidateScanItem[];
     workItems?: LocalCompanionBrowserWorkItem[];
     resumeFile?: ResumeFileData | null;
-  }): Promise<{
+  }, signal?: AbortSignal): Promise<{
     summary: string;
     metadata: Record<string, unknown>;
   }>;
+  registerProgressHandler(runId: string, callback: (event: Record<string, unknown>) => void): void;
+  unregisterProgressHandler(runId: string): void;
   close(): Promise<void>;
 }
 
@@ -209,8 +146,6 @@ export function buildPythonBrowserRuntimeProcessOptions(
           "run",
           "--with",
           "mcp-agent",
-          "--with",
-          "temporalio",
           "--with",
           "openai",
           "--with",
@@ -256,6 +191,7 @@ export async function createPythonBrowserRuntimeConnection(
   });
 
   const pending = new Map<string, PendingBridgeRequest>();
+  const progressHandlers = new Map<string, (event: Record<string, unknown>) => void>();
   let stdoutBuffer = "";
   let stderrBuffer = "";
   let closed = false;
@@ -284,14 +220,26 @@ export async function createPythonBrowserRuntimeConnection(
         continue;
       }
 
-      let response: BridgeResponse;
+      let parsed: Record<string, unknown>;
       try {
-        response = JSON.parse(line) as BridgeResponse;
+        parsed = JSON.parse(line) as Record<string, unknown>;
       } catch {
         logger.warn(`[python-browser-runtime] ignored non-JSON stdout: ${line}`);
         continue;
       }
 
+      if (parsed.__progress__ === true) {
+        const runId = typeof parsed.runId === "string" ? parsed.runId : undefined;
+        if (runId) {
+          const handler = progressHandlers.get(runId);
+          if (handler) {
+            try { handler(parsed); } catch { /* ignore handler errors */ }
+          }
+        }
+        continue;
+      }
+
+      const response = parsed as unknown as BridgeResponse;
       const request = pending.get(response.id);
       if (!request) {
         continue;
@@ -350,10 +298,14 @@ export async function createPythonBrowserRuntimeConnection(
 
   const request = async <TResult>(
     method: BridgeMethod,
-    args?: Record<string, unknown>
+    args?: Record<string, unknown>,
+    signal?: AbortSignal
   ): Promise<TResult> => {
     if (closed) {
       throw new Error("python browser runtime is not running");
+    }
+    if (signal?.aborted) {
+      throw new DOMException("Aborted", "AbortError");
     }
     const id = createRequestId();
     const payload: BridgeRequest = { id, method, ...(args ? { args } : {}) };
@@ -362,6 +314,18 @@ export async function createPythonBrowserRuntimeConnection(
         resolve: (value) => resolve(value as TResult),
         reject,
       });
+
+      if (signal) {
+        signal.addEventListener(
+          "abort",
+          () => {
+            if (pending.delete(id)) {
+              reject(new DOMException("Aborted", "AbortError"));
+            }
+          },
+          { once: true }
+        );
+      }
 
       child.stdin.write(`${JSON.stringify(payload)}\n`, (error) => {
         if (!error) {
@@ -392,51 +356,6 @@ export async function createPythonBrowserRuntimeConnection(
         workItems: LocalCompanionBrowserWorkItem[];
       }>("derive_browser_work_items", args as unknown as Record<string, unknown>);
     },
-    async startGenericBrowserTaskWorkflow(args) {
-      return request<{
-        workflowId: string;
-        runId?: string;
-      }>(
-        "start_generic_browser_task_workflow",
-        args as unknown as Record<string, unknown>
-      );
-    },
-    async startGenericBrowserQueueWorkflow(args) {
-      return request<{
-        workflowId: string;
-        runId?: string;
-      }>(
-        "start_generic_browser_queue_workflow",
-        args as unknown as Record<string, unknown>
-      );
-    },
-    async startLinkedInConnectBatchWorkflow(args) {
-      return request<{
-        workflowId: string;
-        runId?: string;
-      }>(
-        "start_linkedin_connect_batch_workflow",
-        args as unknown as Record<string, unknown>
-      );
-    },
-    async getWorkflowStatus(args) {
-      return request<Record<string, unknown> | null>(
-        "get_workflow_status",
-        args as unknown as Record<string, unknown>
-      );
-    },
-    async resumeWorkflow(args) {
-      return request<boolean>(
-        "resume_workflow",
-        args as unknown as Record<string, unknown>
-      );
-    },
-    async cancelWorkflow(args) {
-      return request<boolean>(
-        "cancel_workflow",
-        args as unknown as Record<string, unknown>
-      );
-    },
     async navigateToUrl(args) {
       return request<{
         summary: string;
@@ -455,11 +374,17 @@ export async function createPythonBrowserRuntimeConnection(
         metadata: Record<string, unknown>;
       }>("execute_linkedin_connect_batch", args as unknown as Record<string, unknown>);
     },
-    async executeAgentTask(args) {
+    async executeAgentTask(args, signal) {
       return request<{
         summary: string;
         metadata: Record<string, unknown>;
-      }>("execute_agent_task", args as unknown as Record<string, unknown>);
+      }>("execute_agent_task", args as unknown as Record<string, unknown>, signal);
+    },
+    registerProgressHandler(runId, callback) {
+      progressHandlers.set(runId, callback);
+    },
+    unregisterProgressHandler(runId) {
+      progressHandlers.delete(runId);
     },
     async close() {
       if (closed || shuttingDown) {

--- a/companion/python_browser_runtime.py
+++ b/companion/python_browser_runtime.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from contextlib import asynccontextmanager, suppress
-from datetime import timedelta
 import json
 import math
 import os
@@ -12,11 +10,10 @@ import random
 import re
 import sys
 import tempfile
-import uuid
 from typing import Any
 from urllib.parse import urlparse
 
-from mcp_agent.agents.agent import Agent, AgentTasks
+from mcp_agent.agents.agent import Agent
 from mcp_agent.app import MCPApp
 from mcp_agent.config import (
     AnthropicSettings,
@@ -26,26 +23,11 @@ from mcp_agent.config import (
     MCPSettings,
     OpenAISettings,
     Settings,
-    TemporalSettings,
 )
-from mcp_agent.executor import temporal as temporal_executor
-from mcp_agent.executor.temporal import (
-    ContextPropagationInterceptor,
-    SystemActivities,
-    TemporalExecutor,
-    Worker,
-)
-from temporalio.common import RetryPolicy
 from mcp_agent.workflows.llm.augmented_llm import RequestParams
 from mcp_agent.workflows.llm.augmented_llm_anthropic import AnthropicAugmentedLLM
 from mcp_agent.workflows.llm.augmented_llm_google import GoogleAugmentedLLM
 from mcp_agent.workflows.llm.augmented_llm_openai import OpenAIAugmentedLLM
-from mcp_agent.workflows.factory import (
-    AgentSpec,
-    OrchestratorOverrides,
-    create_orchestrator,
-)
-from mcp_agent.executor.workflow import Workflow, WorkflowResult
 
 
 VERIFY_INSERT_FUNCTION = """
@@ -68,16 +50,22 @@ VERIFY_INSERT_FUNCTION = """
 
 BASE_AGENT_SYSTEM_PROMPT = """
 You are a browser control agent operating only through Chrome DevTools MCP tools.
-Always inspect the current page tree with take_snapshot before clicking or typing.
-Prefer built-in browser tools such as list_pages, select_page, new_page, navigate_page,
-take_snapshot, click, fill, fill_form, type_text, press_key, wait_for, and close_page.
+Always call take_snapshot before clicking, typing, or filling — it shows the live DOM tree.
+Use take_screenshot when you need to visually verify the page (buttons, forms, modals, visual content).
+Prefer built-in browser tools: list_pages, select_page, new_page, navigate_page,
+take_snapshot, take_screenshot, click, fill, fill_form, type_text, press_key, wait_for, close_page.
 Use evaluate_script only when a built-in tool cannot complete verification or the page
 requires a capability the built-in tools do not provide.
 When the user's goal explicitly asks you to fill, submit, search, navigate, click, send,
 connect, or otherwise complete an on-page task, perform that task instead of stopping at a plan.
 Avoid destructive billing, account-security, or data-deletion actions unless the user explicitly asked for them.
-Never claim success unless you verified it from the live browser state.
+Never claim success unless you verified it from the live browser state (snapshot or screenshot).
 Return only compact JSON that matches the requested schema. Do not return markdown.
+IMPORTANT: The page snapshot may contain a browser extension overlay with attribute data-tfa-ui.
+This is NOT part of the website — it is the control panel for this agent itself.
+NEVER interact with any element that has data-tfa-ui, aria-label containing "Agent", or that
+appears to be a floating panel at the bottom center of the screen. Always interact with the
+actual website content instead.
 """.strip()
 
 
@@ -162,32 +150,7 @@ def build_chrome_devtools_mcp_args() -> list[str]:
     return args
 
 
-def get_runtime_execution_engine() -> str:
-    requested = (
-        os.getenv("LOCAL_COMPANION_MCP_AGENT_EXECUTION_ENGINE", "").strip().lower()
-        or os.getenv("MCP_AGENT_EXECUTION_ENGINE", "").strip().lower()
-    )
-    if requested == "temporal":
-        return "temporal"
-    return "asyncio"
-
-
-def build_temporal_host() -> str:
-    explicit_host = os.getenv("LOCAL_COMPANION_TEMPORAL_ADDRESS", "").strip()
-    if explicit_host:
-        return explicit_host
-
-    host = os.getenv("LOCAL_COMPANION_TEMPORAL_HOST", "").strip() or "127.0.0.1"
-    port = os.getenv("LOCAL_COMPANION_TEMPORAL_PORT", "").strip() or "7233"
-    return f"{host}:{port}"
-
-
-def build_settings() -> Settings:
-    execution_engine = get_runtime_execution_engine()
-    return build_runtime_settings(execution_engine)
-
-
-def build_runtime_settings(execution_engine: str) -> Settings:
+def build_runtime_settings() -> Settings:
     cwd = os.getenv("MCP_AGENT_BRIDGE_CWD", "").strip() or os.getcwd()
     command = os.getenv("CHROME_DEVTOOLS_MCP_COMMAND", "").strip() or "npx"
     allowed_env = {
@@ -196,7 +159,7 @@ def build_runtime_settings(execution_engine: str) -> Settings:
 
     settings = Settings(
         name="cheatresume_python_browser_runtime",
-        execution_engine=execution_engine,
+        execution_engine="asyncio",
         logger=LoggerSettings(
             type="none",
             transports=["none"],
@@ -215,19 +178,6 @@ def build_runtime_settings(execution_engine: str) -> Settings:
             }
         ),
     )
-    if execution_engine == "temporal":
-        settings.temporal = TemporalSettings(
-            host=build_temporal_host(),
-            namespace=(
-                os.getenv("LOCAL_COMPANION_TEMPORAL_NAMESPACE", "").strip()
-                or "default"
-            ),
-            task_queue=(
-                os.getenv("LOCAL_COMPANION_TEMPORAL_TASK_QUEUE", "").strip()
-                or "cheatresume-browser-agent"
-            ),
-            workflow_task_modules=[],
-        )
     return settings
 
 
@@ -343,6 +293,86 @@ def summarize_json_value(value: Any, max_length: int = 400) -> str:
     return truncate_text(serialized, max_length)
 
 
+_SITE_URL_MAP: dict[str, str] = {
+    "amazon": "https://www.amazon.com",
+    "google": "https://www.google.com",
+    "linkedin": "https://www.linkedin.com",
+    "github": "https://www.github.com",
+    "twitter": "https://www.twitter.com",
+    "x.com": "https://www.x.com",
+    "facebook": "https://www.facebook.com",
+    "instagram": "https://www.instagram.com",
+    "reddit": "https://www.reddit.com",
+    "youtube": "https://www.youtube.com",
+    "gmail": "https://mail.google.com",
+    "outlook": "https://outlook.live.com",
+    "slack": "https://slack.com",
+    "notion": "https://www.notion.so",
+    "shopify": "https://www.shopify.com",
+    "ebay": "https://www.ebay.com",
+    "etsy": "https://www.etsy.com",
+    "wikipedia": "https://www.wikipedia.org",
+    "scholar": "https://scholar.google.com",
+    "google scholar": "https://scholar.google.com",
+}
+
+_URL_RE = re.compile(r"https?://[^\s\"'<>]+", re.IGNORECASE)
+_DOMAIN_RE = re.compile(r"\b([\w-]+\.(?:com|org|net|io|co|gov|edu|app|dev))\b", re.IGNORECASE)
+
+
+def _extract_step_target_url(step: dict[str, Any], current_url: str) -> str | None:
+    """
+    If a step clearly intends to navigate to a specific site and the browser is
+    NOT already there, return the target URL so _execute_step can pre-navigate.
+    Returns None when no pre-navigation is needed.
+    """
+    title = str(step.get("title") or "").strip().lower()
+    description = str(step.get("description") or "").strip()
+
+    # Only activate for navigation-intent steps.
+    nav_keywords = ("navigate to", "go to", "open ", "visit ")
+    if not any(title.startswith(kw) or title.startswith("navigate") for kw in nav_keywords):
+        if "navigate to" not in title and not title.startswith("go to") and not title.startswith("open "):
+            return None
+
+    # 1. Explicit URL in description takes highest priority.
+    url_match = _URL_RE.search(description)
+    if url_match:
+        target = url_match.group(0).rstrip(".,)")
+        try:
+            from urllib.parse import urlparse
+            parsed_target = urlparse(target)
+            parsed_current = urlparse(current_url)
+            if parsed_target.netloc and parsed_target.netloc != parsed_current.netloc:
+                return target
+        except Exception:
+            pass
+
+    # 2. Well-known site name in step title.
+    for site_name, site_url in _SITE_URL_MAP.items():
+        if site_name in title:
+            try:
+                from urllib.parse import urlparse
+                if urlparse(current_url).netloc not in site_url:
+                    return site_url
+            except Exception:
+                pass
+            break
+
+    # 3. Domain pattern in description (e.g. "navigate to shopify.com").
+    domain_match = _DOMAIN_RE.search(description)
+    if domain_match:
+        domain = domain_match.group(1)
+        try:
+            from urllib.parse import urlparse
+            if domain not in urlparse(current_url).netloc:
+                return f"https://www.{domain}"
+        except Exception:
+            pass
+
+    return None
+
+
 def extract_json_payload(text: str) -> dict[str, Any]:
     candidates: list[str] = [text.strip()]
     candidates.extend(
@@ -441,131 +471,6 @@ def write_resume_to_temp(resume_file: dict[str, Any]) -> str | None:
         return tmp.name
     except Exception:
         return None
-
-
-def build_general_task_prompt(payload: dict[str, Any]) -> str:
-    parts = [
-        "Task:",
-        str(payload.get("goal") or "").strip(),
-        "",
-        "Constraints:",
-        "- Use Chrome DevTools MCP tools only.",
-        "- Complete the requested browser task end-to-end when the goal is explicit.",
-        "- You may click, type, fill, submit, send, connect, search, and navigate when needed to satisfy the goal.",
-        "- Do not perform billing, password, account-deletion, or irreversible security actions unless the user explicitly asked for them.",
-        "- Prefer the current page if it matches the task. You may navigate or open pages when needed.",
-        "- Use take_snapshot to inspect the page tree before interacting.",
-        "- Verify the result from the live page before finishing.",
-    ]
-
-    page_url = str(payload.get("pageUrl") or "").strip()
-    if page_url:
-        parts.extend(["", f"Current page URL: {page_url}"])
-
-    platform_hint = str(payload.get("platformHint") or "").strip()
-    if platform_hint:
-        parts.append(f"Platform hint: {platform_hint}")
-
-    page_context = str(payload.get("pageContext") or "").strip()
-    if page_context:
-        parts.extend(["", "Observed page context:", page_context[:4000]])
-
-    resume_context = str(payload.get("resumeContext") or "").strip()
-    if resume_context:
-        parts.extend(["", "Continuation context:", resume_context[:4000]])
-
-    site_experience_context = str(payload.get("siteExperienceContext") or "").strip()
-    if site_experience_context:
-        parts.extend(["", "What has worked on similar pages before:", site_experience_context[:4000]])
-
-    user_context = str(payload.get("userContext") or "").strip()
-    if user_context:
-        parts.extend(["", "User-specific context:", user_context[:4000]])
-
-    current_work_item = payload.get("currentWorkItem")
-    if isinstance(current_work_item, dict) and current_work_item:
-        work_item_lines: list[str] = []
-        work_item_title = str(current_work_item.get("title") or "").strip()
-        if work_item_title:
-            work_item_lines.append(f"Work item: {work_item_title}")
-        work_item_goal = str(current_work_item.get("itemGoal") or "").strip()
-        if work_item_goal:
-            work_item_lines.append(f"Item goal: {work_item_goal}")
-        work_item_target = str(
-            current_work_item.get("targetName")
-            or current_work_item.get("targetUrl")
-            or current_work_item.get("pageUrl")
-            or ""
-        ).strip()
-        if work_item_target:
-            work_item_lines.append(f"Target: {work_item_target}")
-        work_item_context = str(current_work_item.get("itemContext") or "").strip()
-        if work_item_context:
-            work_item_lines.append(truncate_text(work_item_context, 2500))
-        if work_item_lines:
-            parts.extend(["", "Current queued work item:", *work_item_lines])
-
-    # Resume file attachment — write to temp and pass path to agent
-    resume_file = payload.get("resumeFile")
-    if isinstance(resume_file, dict) and resume_file.get("base64"):
-        resume_tmp_path = write_resume_to_temp(resume_file)
-        if resume_tmp_path:
-            resume_name = str(resume_file.get("name") or "resume.pdf").strip()
-            parts.extend([
-                "",
-                "=== Resume File ===",
-                f"The user's resume has been saved to a temporary file at: {resume_tmp_path}",
-                f"Original filename: {resume_name}",
-                "When you encounter a file upload input asking for a resume (e.g. input[type='file']), "
-                "use the Chrome DevTools 'set_file_input_files' tool (or equivalent CDP method) "
-                f"with the path '{resume_tmp_path}' to attach the file.",
-                "Alternatively, use evaluate_script with this JavaScript to attach the resume programmatically:",
-                "(async () => {",
-                "  const input = document.querySelector('input[type=\"file\"]');",
-                "  if (!input) return 'No file input found';",
-                f"  const response = await fetch('file://{resume_tmp_path}');",
-                "  const blob = await response.blob();",
-                f"  const file = new File([blob], '{resume_name}', {{ type: blob.type }});",
-                "  const dt = new DataTransfer(); dt.items.add(file);",
-                "  Object.defineProperty(input, 'files', { value: dt.files, writable: true });",
-                "  input.dispatchEvent(new Event('change', { bubbles: true }));",
-                "  return 'Resume attached';",
-                "})();",
-            ])
-
-    field_target = payload.get("fieldTarget")
-    if isinstance(field_target, dict):
-        selector = str(field_target.get("selector") or "").strip()
-        if selector:
-            parts.extend(["", f"Known field selector: {selector}"])
-
-    structured = payload.get("structured")
-    if isinstance(structured, dict) and structured:
-        parts.extend(
-            [
-                "",
-                "Structured observation:",
-                truncate_text(json.dumps(structured, ensure_ascii=True), 2500),
-            ]
-        )
-
-    scanned_candidates = payload.get("scannedCandidates")
-    if isinstance(scanned_candidates, list) and scanned_candidates:
-        parts.extend(
-            [
-                "",
-                "Candidate scan hints:",
-                truncate_text(json.dumps(scanned_candidates[:8], ensure_ascii=True), 2000),
-            ]
-        )
-
-    parts.extend(
-        [
-            "",
-            'Return JSON: {"summary":"...", "status":"completed|skipped|failed", "finalUrl":"optional", "notes":["optional"]}',
-        ]
-    )
-    return "\n".join(parts)
 
 
 def build_work_item_discovery_prompt(payload: dict[str, Any]) -> str:
@@ -724,1008 +629,19 @@ def build_linkedin_connect_prompt(item: dict[str, Any]) -> str:
     )
 
 
-def is_linkedin_profile_connect_goal(payload: dict[str, Any]) -> bool:
-    goal = str(payload.get("goal") or "").strip().lower()
-    platform_hint = str(payload.get("platformHint") or "").strip().lower()
-    page_url = str(payload.get("pageUrl") or "").strip().lower()
-
-    if not goal:
-        return False
-
-    is_linkedin = platform_hint == "linkedin" or "linkedin.com" in page_url
-    is_profile = "/linkedin.com/in/" in page_url or "linkedin.com/in/" in page_url
-    wants_connect = any(
-        phrase in goal
-        for phrase in (
-            "connect",
-            "connection request",
-            "invite",
-            "add a note",
-            "connection note",
-        )
-    )
-    return is_linkedin and is_profile and wants_connect
-
-
-def extract_linkedin_target_name(payload: dict[str, Any]) -> str | None:
-    structured = payload.get("structured")
-    if isinstance(structured, dict):
-        data = structured.get("data")
-        if isinstance(data, dict):
-            for key in ("name", "title"):
-                value = str(data.get(key) or "").strip()
-                if value:
-                    return value
-
-    page_context = str(payload.get("pageContext") or "").strip()
-    match = re.search(r"Page:\s*([^\n]+)", page_context)
-    if match:
-        value = match.group(1).strip()
-        if value:
-            return value
-
-    return None
-
-
-def coerce_generic_work_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
-    raw_items = payload.get("workItems")
-    if not isinstance(raw_items, list):
-        return []
-
-    items: list[dict[str, Any]] = []
-    for index, raw_item in enumerate(raw_items):
-        if not isinstance(raw_item, dict):
-            continue
-        title = str(raw_item.get("title") or "").strip()
-        page_url = str(raw_item.get("pageUrl") or raw_item.get("targetUrl") or "").strip()
-        target_name = str(raw_item.get("targetName") or "").strip()
-        item_goal = str(raw_item.get("itemGoal") or "").strip()
-        item_context = str(raw_item.get("itemContext") or "").strip()
-        if not title:
-            if target_name:
-                title = f"Handle {target_name}"
-            elif page_url:
-                title = f"Handle item {index + 1}"
-            else:
-                continue
-        items.append(
-            {
-                "title": title,
-                **({"pageUrl": page_url} if page_url else {}),
-                **({"targetName": target_name} if target_name else {}),
-                **({"itemGoal": item_goal} if item_goal else {}),
-                **({"itemContext": item_context} if item_context else {}),
-                **(
-                    {"sourceType": str(raw_item.get("sourceType") or "").strip()}
-                    if str(raw_item.get("sourceType") or "").strip()
-                    else {}
-                ),
-            }
-        )
-    return items
-
-
-def build_generic_queue_item_payload(
-    payload: dict[str, Any], item: dict[str, Any]
-) -> dict[str, Any]:
-    item_payload = dict(payload)
-    item_payload["currentWorkItem"] = item
-
-    item_page_url = str(item.get("pageUrl") or item.get("targetUrl") or "").strip()
-    if item_page_url:
-        item_payload["pageUrl"] = item_page_url
-
-    item_goal = str(item.get("itemGoal") or "").strip()
-    if item_goal:
-        item_payload["goal"] = item_goal
-
-    item_context = str(item.get("itemContext") or "").strip()
-    if item_context:
-        existing_page_context = str(item_payload.get("pageContext") or "").strip()
-        item_payload["pageContext"] = (
-            f"{existing_page_context}\n\nQueued work item context:\n{item_context}"
-            if existing_page_context
-            else f"Queued work item context:\n{item_context}"
-        )
-
-    target_name = str(item.get("targetName") or "").strip()
-    if target_name:
-        item_payload["scannedCandidates"] = [
-            {
-                "targetName": target_name,
-                "targetUrl": item_page_url,
-            }
-        ]
-
-    return item_payload
-
-
-def build_generic_orchestrator_overrides() -> OrchestratorOverrides:
-    def get_task_prompt(objective: str, task: str, context: str) -> str:
-        parts = [
-            "You are the browser operator for one subtask of a larger browser goal.",
-            "Use Chrome DevTools MCP tools only.",
-            "Inspect the live page tree before interacting.",
-            "Prefer reusing the current page or open tabs before opening new pages.",
-            "Verify each meaningful action from the live browser state.",
-            "If the current page already reflects completed work, do not repeat it.",
-            "",
-            f"Overall objective:\n{objective}",
-            "",
-            f"Assigned subtask:\n{task}",
-        ]
-        if context.strip():
-            parts.extend(["", f"Context from earlier steps:\n{context}"])
-        parts.extend(
-            [
-                "",
-                "Return a concise plain-text result for this subtask. Do not return markdown.",
-            ]
-        )
-        return "\n".join(parts)
-
-    return OrchestratorOverrides(
-        planner_instruction=(
-            "You are planning a browser task. Break the objective into 1-4 concrete steps. "
-            "Prefer verifying existing browser state before repeating work. "
-            "Keep the plan short, action-oriented, and grounded in the current page."
-        ),
-        synthesizer_instruction=(
-            "Synthesize the subtask results into the final compact JSON requested by the objective. "
-            "Return JSON only. If the task is incomplete or blocked, set status to failed and explain why."
-        ),
-        get_task_prompt=get_task_prompt,
-    )
-
-
-def normalize_orchestrator_task_steps(plan_result: Any) -> list[dict[str, Any]]:
-    step_results = getattr(plan_result, "step_results", None)
-    if not isinstance(step_results, list):
-        return []
-
-    normalized_steps: list[dict[str, Any]] = []
-    for step_index, step_result in enumerate(step_results):
-        step = getattr(step_result, "step", None)
-        title = str(getattr(step, "description", "") or "").strip()
-        if not title:
-            title = f"Step {step_index + 1}"
-
-        task_summaries: list[dict[str, Any]] = []
-        task_results = getattr(step_result, "task_results", None)
-        if isinstance(task_results, list):
-            for task_index, task_result in enumerate(task_results):
-                task_title = str(getattr(task_result, "description", "") or "").strip()
-                if not task_title:
-                    task_title = f"Task {task_index + 1}"
-                task_result_summary = str(
-                    getattr(task_result, "result", "") or ""
-                ).strip()
-                task_summaries.append(
-                    {
-                        "title": task_title,
-                        "status": "completed",
-                        **(
-                            {"resultSummary": task_result_summary}
-                            if task_result_summary
-                            else {}
-                        ),
-                    }
-                )
-
-        step_result_summary = str(getattr(step_result, "result", "") or "").strip()
-        if not step_result_summary and task_summaries:
-            step_result_summary = " | ".join(
-                str(task.get("resultSummary") or "").strip()
-                for task in task_summaries
-                if str(task.get("resultSummary") or "").strip()
-            )
-
-        normalized_steps.append(
-            {
-                "title": title,
-                "status": "completed",
-                **(
-                    {"resultSummary": step_result_summary}
-                    if step_result_summary
-                    else {}
-                ),
-                **({"tasks": task_summaries} if task_summaries else {}),
-            }
-        )
-
-    return normalized_steps
-
-
-def is_retryable_browser_workflow_error(message: str) -> bool:
-    normalized = message.strip().lower()
-    if not normalized:
-        return True
-    non_retryable_markers = (
-        "missing api key",
-        "providerconfig is required",
-        "unsupported provider",
-        "a linkedin profile url is required",
-        "browser agent returned a response that was not valid json",
-    )
-    return not any(marker in normalized for marker in non_retryable_markers)
-
-
-def build_retry_resume_context(
-    *,
-    existing_resume_context: str,
-    attempt: int,
-    error_message: str,
-    page_state: dict[str, Any],
-) -> str:
-    parts: list[str] = []
-    trimmed_existing = existing_resume_context.strip()
-    if trimmed_existing:
-        parts.append(trimmed_existing)
-
-    parts.extend(
-        [
-            f"Retry attempt {attempt} after the browser task failed.",
-            f"Last error: {error_message}",
-        ]
-    )
-
-    page_url = str(page_state.get("pageUrl") or "").strip()
-    if page_url:
-        parts.append(f"Current page URL after failure: {page_url}")
-
-    page_title = str(page_state.get("pageTitle") or "").strip()
-    if page_title:
-        parts.append(f"Current page title after failure: {page_title}")
-
-    # Skip including the full page snapshot in retry context — it bloats Temporal
-    # workflow history and the agent will call take_snapshot fresh on the next attempt.
-    # The URL and title above are sufficient for the agent to orient itself.
-
-    parts.append(
-        "Do not restart from scratch if the page already reflects prior progress. Inspect the live page and continue from the furthest verified checkpoint."
-    )
-    return "\n\n".join(parts)
-
-
-def build_resume_signal_context(
-    *,
-    existing_resume_context: str,
-    resume_count: int,
-    pause_reason: str,
-    signal_payload: Any,
-) -> str:
-    parts: list[str] = []
-    trimmed_existing = existing_resume_context.strip()
-    if trimmed_existing:
-        parts.append(trimmed_existing)
-
-    parts.extend(
-        [
-            f"Workflow resume cycle {resume_count} after a paused browser task.",
-            f"Reason the workflow paused: {pause_reason}",
-        ]
-    )
-
-    if isinstance(signal_payload, dict):
-        signal_resume_context = str(signal_payload.get("resumeContext") or "").strip()
-        if signal_resume_context:
-            parts.append(f"Resume instructions from the user:\n{signal_resume_context}")
-
-        page_url = str(signal_payload.get("pageUrl") or "").strip()
-        if page_url:
-            parts.append(f"Current page URL at resume time: {page_url}")
-
-        page_context = str(signal_payload.get("pageContext") or "").strip()
-        if page_context:
-            parts.append(
-                "Observed page context at resume time:\n"
-                + truncate_text(page_context, 2500)
-            )
-
-        user_context = str(signal_payload.get("userContext") or "").strip()
-        if user_context:
-            parts.append(
-                "User-specific context supplied again at resume time:\n"
-                + truncate_text(user_context, 2500)
-            )
-
-        structured = signal_payload.get("structured")
-        if isinstance(structured, dict) and structured:
-            parts.append(
-                "Structured observation at resume time:\n"
-                + truncate_text(json.dumps(structured, ensure_ascii=True), 2500)
-            )
-
-        scanned_candidates = signal_payload.get("scannedCandidates")
-        if isinstance(scanned_candidates, list) and scanned_candidates:
-            parts.append(
-                "Candidate scan hints at resume time:\n"
-                + truncate_text(
-                    json.dumps(scanned_candidates[:8], ensure_ascii=True), 2000
-                )
-            )
-    else:
-        payload_text = str(signal_payload or "").strip()
-        if payload_text:
-            parts.append(f"Resume instructions from the user:\n{payload_text}")
-
-    parts.append(
-        "Resume from the furthest verified checkpoint. Re-check the live page before repeating any step that may already be complete."
-    )
-    return "\n\n".join(parts)
-
-
-def merge_resume_signal_payload(
-    *,
-    current_payload: dict[str, Any],
-    signal_payload: Any,
-    pause_reason: str,
-    resume_count: int,
-) -> dict[str, Any]:
-    merged_payload = dict(current_payload)
-    normalized_signal_payload = (
-        dict(signal_payload) if isinstance(signal_payload, dict) else None
-    )
-
-    if normalized_signal_payload is not None:
-        for key in (
-            "goal",
-            "pageUrl",
-            "platformHint",
-            "pageContext",
-            "siteExperienceContext",
-            "userContext",
-            "systemPrompt",
-        ):
-            value = normalized_signal_payload.get(key)
-            if isinstance(value, str) and value.strip():
-                merged_payload[key] = value.strip()
-
-        field_target = normalized_signal_payload.get("fieldTarget")
-        if isinstance(field_target, dict) and field_target:
-            merged_payload["fieldTarget"] = dict(field_target)
-
-        structured = normalized_signal_payload.get("structured")
-        if isinstance(structured, dict) and structured:
-            merged_payload["structured"] = dict(structured)
-
-        scanned_candidates = normalized_signal_payload.get("scannedCandidates")
-        if isinstance(scanned_candidates, list):
-            merged_payload["scannedCandidates"] = list(scanned_candidates)
-
-        resume_file = normalized_signal_payload.get("resumeFile")
-        if isinstance(resume_file, dict) and resume_file:
-            merged_payload["resumeFile"] = dict(resume_file)
-
-    merged_payload["resumeContext"] = build_resume_signal_context(
-        existing_resume_context=str(current_payload.get("resumeContext") or ""),
-        resume_count=resume_count,
-        pause_reason=pause_reason,
-        signal_payload=signal_payload,
-    )
-    return merged_payload
-
-
-def _get_workflow_runtime_app(workflow_instance: Workflow[Any]) -> MCPApp:
-    app = getattr(getattr(workflow_instance, "context", None), "app", None)
-    if not isinstance(app, MCPApp):
-        raise RuntimeError("Workflow browser execution requires an initialized app.")
-    return app
-
-
-def _build_workflow_runtime(workflow_instance: Workflow[Any]) -> PythonBrowserRuntime:
-    runtime_owner = getattr(workflow_instance.__class__, "_runtime_owner", None)
-    if isinstance(runtime_owner, PythonBrowserRuntime):
-        return runtime_owner
-    return PythonBrowserRuntime(None, app=_get_workflow_runtime_app(workflow_instance))
-
-
-def _build_registered_workflow_run_method(
-    app: MCPApp,
-    workflow_name: str,
-    base_cls: type[Workflow[dict[str, Any]]],
-):
-    async def run(self, payload: dict[str, Any]) -> WorkflowResult[dict[str, Any]]:
-        return await base_cls.run(self, payload)
-
-    run.__name__ = "run"
-    run.__qualname__ = f"{workflow_name}.run"
-    run.__module__ = __name__
-    return app.workflow_run(run)
-
-
-def _register_runtime_workflow_class(
-    *,
-    runtime: PythonBrowserRuntime,
-    app: MCPApp,
-    workflow_name: str,
-    base_cls: type[Workflow[dict[str, Any]]],
-) -> type[Workflow[dict[str, Any]]]:
-    workflow_cls = type(
-        workflow_name,
-        (base_cls,),
-        {
-            "__module__": __name__,
-            "__doc__": getattr(base_cls, "__doc__", None),
-            "_runtime_owner": runtime,
-            "run": _build_registered_workflow_run_method(
-                app,
-                workflow_name,
-                base_cls,
-            ),
-        },
-    )
-    return app.workflow(workflow_cls, workflow_id=workflow_name)
-
-
-class GenericBrowserTaskWorkflowBase(Workflow[dict[str, Any]]):
-    async def run(
-        self, payload: dict[str, Any]
-    ) -> WorkflowResult[dict[str, Any]]:
-        # NOTE: We do NOT use workflow_attempt_runtime / call_tool_task activities here.
-        # Each MCP tool call (take_snapshot, click, etc.) returns a full DOM snapshot
-        # (~50-100 KB).  Routing those through Temporal activities stores every snapshot
-        # in the workflow history, blowing it past the 512 KB-per-payload limit after
-        # only ~12 tool calls.  Instead, the entire browser task (all LLM + MCP calls)
-        # runs as ONE Temporal activity ("execute_browser_task") so only the final
-        # small JSON result is persisted in Temporal history.
-        from temporalio import workflow as _tw
-
-        app = _get_workflow_runtime_app(self)
-        max_attempts = 3
-        max_resume_cycles = 2
-        attempt_history: list[dict[str, Any]] = []
-        current_payload = dict(payload)
-        resume_count = 0
-
-        while True:
-            for attempt in range(1, max_attempts + 1):
-                self.update_status("running")
-                self.state.metadata["attempts"] = attempt
-                self.state.metadata["resumeCount"] = resume_count
-                self.state.metadata["recoveryHistory"] = attempt_history
-
-                try:
-                    # Dispatch the entire browser task as a single long-running activity.
-                    # start_to_close_timeout: maximum wall-clock time for one attempt.
-                    # heartbeat_timeout: Temporal will cancel the activity if it stops
-                    #   heartbeating for this long (the activity sends heartbeats every 30s).
-                    outcome = await _tw.execute_activity(
-                        "execute_browser_task",
-                        args=[current_payload],
-                        start_to_close_timeout=timedelta(minutes=90),
-                        heartbeat_timeout=timedelta(seconds=120),
-                        retry_policy=RetryPolicy(
-                            initial_interval=timedelta(seconds=60),
-                            maximum_interval=timedelta(minutes=5),
-                            maximum_attempts=5,
-                        ),
-                    )
-
-                    metadata: dict[str, Any] = {
-                        "workflowName": "GenericBrowserTaskWorkflow",
-                        "executionEngine": str(
-                            app.context.config.execution_engine
-                        ),
-                        "attempts": attempt,
-                        "resumeCount": resume_count,
-                        "recovered": attempt > 1 or resume_count > 0,
-                        "recoveryHistory": attempt_history,
-                    }
-                    outcome_metadata = outcome.get("metadata")
-                    if isinstance(outcome_metadata, dict):
-                        task_steps = outcome_metadata.get("taskSteps")
-                        if isinstance(task_steps, list) and task_steps:
-                            metadata["taskSteps"] = task_steps
-                        execution_mode = str(
-                            outcome_metadata.get("executionMode") or ""
-                        ).strip()
-                        if execution_mode:
-                            metadata["executionMode"] = execution_mode
-                        final_url = str(
-                            outcome_metadata.get("finalUrl") or ""
-                        ).strip()
-                        if final_url:
-                            metadata["finalUrl"] = final_url
-                            self.state.metadata["latestPageUrl"] = final_url
-
-                    self.state.metadata.pop("pauseReason", None)
-                    self.state.metadata.pop("awaitingSignal", None)
-                    self.state.metadata.pop("lastError", None)
-                    self.state.metadata.update(metadata)
-                    return WorkflowResult(value=outcome, metadata=metadata)
-
-                except Exception as error:
-                    message = normalize_error_message(
-                        error if isinstance(error, Exception) else Exception(str(error))
-                    )
-                    history_item: dict[str, Any] = {
-                        "attempt": attempt,
-                        "resumeCount": resume_count,
-                        "error": message,
-                    }
-                    latest_url = str(
-                        self.state.metadata.get("latestPageUrl") or ""
-                    ).strip()
-                    if latest_url:
-                        history_item["pageUrl"] = latest_url
-                    attempt_history.append(history_item)
-                    self.state.metadata["lastError"] = message
-                    self.state.metadata["recoveryHistory"] = attempt_history
-
-                    if not is_retryable_browser_workflow_error(message):
-                        raise
-
-                    if attempt < max_attempts:
-                        current_payload = dict(current_payload)
-                        current_payload["resumeContext"] = build_retry_resume_context(
-                            existing_resume_context=str(
-                                current_payload.get("resumeContext") or ""
-                            ),
-                            attempt=attempt,
-                            error_message=message,
-                            page_state={"pageUrl": latest_url},
-                        )
-                        continue
-
-                    if resume_count >= max_resume_cycles:
-                        raise
-
-                    self.update_status("paused")
-                    self.state.metadata["pauseReason"] = message
-                    self.state.metadata["awaitingSignal"] = "resume"
-                    resume_payload = await app.context.executor.wait_for_signal(
-                        signal_name="resume",
-                        workflow_id=self.id,
-                        run_id=self.run_id,
-                        signal_description=(
-                            "Workflow paused after repeated browser-task failures. "
-                            "Resume to continue from the last checkpoint."
-                        ),
-                    )
-                    resume_count += 1
-                    current_payload = merge_resume_signal_payload(
-                        current_payload=current_payload,
-                        signal_payload=resume_payload,
-                        pause_reason=message,
-                        resume_count=resume_count,
-                    )
-                    self.update_status("running")
-                    self.state.metadata["resumeCount"] = resume_count
-                    self.state.metadata.pop("awaitingSignal", None)
-                    self.state.metadata.pop("pauseReason", None)
-                    break
-
-
-class GenericBrowserQueueWorkflowBase(Workflow[dict[str, Any]]):
-    async def run(
-        self, payload: dict[str, Any]
-    ) -> WorkflowResult[dict[str, Any]]:
-        from temporalio import workflow as _tw
-        items = coerce_generic_work_items(payload)
-        if not items:
-            raise RuntimeError("workItems are required")
-
-        completed = 0
-        skipped = 0
-        failed = 0
-        task_steps: list[dict[str, Any]] = []
-
-        for item in items:
-            page_url = str(item.get("pageUrl") or "").strip()
-            task_steps.append(
-                {
-                    "title": str(item.get("title") or "Queued browser task").strip(),
-                    "status": "pending",
-                    **({"pageUrl": page_url} if page_url else {}),
-                }
-            )
-
-        self.state.metadata.update(
-            {
-                "workflowName": "GenericBrowserQueueWorkflow",
-                "queueType": "generic_browser_queue",
-                "itemCount": len(items),
-                "completed": 0,
-                "skipped": 0,
-                "failed": 0,
-                "taskSteps": task_steps,
-            }
-        )
-
-        for index, item in enumerate(items):
-            self.update_status("running")
-            step = task_steps[index]
-            step["status"] = "running"
-            step["retryCount"] = 0
-            current_page_url = str(item.get("pageUrl") or "").strip()
-            if current_page_url:
-                self.state.metadata["latestPageUrl"] = current_page_url
-            self.state.metadata["taskSteps"] = task_steps
-
-            item_result: dict[str, Any] | None = None
-            item_error: str | None = None
-            max_attempts = 3
-
-            for attempt in range(1, max_attempts + 1):
-                step["retryCount"] = attempt - 1
-                step["status"] = "running" if attempt == 1 else "retrying"
-                self.state.metadata["taskSteps"] = task_steps
-                try:
-                    item_payload = build_generic_queue_item_payload(payload, item)
-                    item_result = await _tw.execute_activity(
-                        "execute_browser_task",
-                        args=[item_payload],
-                        start_to_close_timeout=timedelta(minutes=90),
-                        heartbeat_timeout=timedelta(seconds=120),
-                        retry_policy=RetryPolicy(
-                            initial_interval=timedelta(seconds=60),
-                            maximum_interval=timedelta(minutes=5),
-                            maximum_attempts=5,
-                        ),
-                    )
-                    break
-                except Exception as error:
-                    item_error = normalize_error_message(
-                        error
-                        if isinstance(error, Exception)
-                        else Exception(str(error))
-                    )
-                    if attempt >= max_attempts:
-                        break
-                    await asyncio.sleep(human_delay(1600) / 1000)
-
-                if item_result is None:
-                    failed += 1
-                    step["status"] = "failed"
-                    step["lastError"] = item_error or "Queued browser task failed."
-                    self.state.metadata["failed"] = failed
-                    self.state.metadata["taskSteps"] = task_steps
-                    continue
-
-                metadata = (
-                    dict(item_result.get("metadata"))
-                    if isinstance(item_result.get("metadata"), dict)
-                    else {}
-                )
-                outcome_status = (
-                    str(metadata.get("status") or item_result.get("status") or "")
-                    .strip()
-                    .lower()
-                )
-                result_summary = str(item_result.get("summary") or "").strip()
-                final_url = str(metadata.get("finalUrl") or "").strip()
-                if final_url:
-                    step["pageUrl"] = final_url
-                    self.state.metadata["latestPageUrl"] = final_url
-
-                if outcome_status == "skipped":
-                    skipped += 1
-                    step["status"] = "skipped"
-                    if result_summary:
-                        step["skipReason"] = result_summary
-                else:
-                    completed += 1
-                    step["status"] = "completed"
-
-                if result_summary:
-                    step["resultSummary"] = result_summary
-
-                self.state.metadata["completed"] = completed
-                self.state.metadata["skipped"] = skipped
-                self.state.metadata["failed"] = failed
-                self.state.metadata["taskSteps"] = task_steps
-                await asyncio.sleep(human_delay(1200) / 1000)
-
-        summary_parts = [
-            f"Queued browser workflow finished for {len(items)} item{'s' if len(items) != 1 else ''}.",
-            f"Completed: {completed}.",
-        ]
-        if skipped > 0:
-            summary_parts.append(f"Skipped: {skipped}.")
-        if failed > 0:
-            summary_parts.append(f"Failed: {failed}.")
-
-        metadata = {
-            "kind": "execute_task_queue",
-            "workflowName": "GenericBrowserQueueWorkflow",
-            "queueType": "generic_browser_queue",
-            "itemCount": len(items),
-            "completed": completed,
-            "skipped": skipped,
-            "failed": failed,
-            "taskSteps": task_steps,
-        }
-        latest_page_url = str(self.state.metadata.get("latestPageUrl") or "").strip()
-        if latest_page_url:
-            metadata["finalUrl"] = latest_page_url
-
-        return WorkflowResult(
-            value={
-                "summary": " ".join(summary_parts),
-                "metadata": metadata,
-            },
-            metadata=metadata,
-        )
-
-
-class LinkedInConnectBatchWorkflowBase(Workflow[dict[str, Any]]):
-    async def run(
-        self, payload: dict[str, Any]
-    ) -> WorkflowResult[dict[str, Any]]:
-        from temporalio import workflow as _tw
-        raw_items = payload.get("items")
-        daily_limit = payload.get("dailyLimit")
-        provider_config = payload.get("providerConfig")
-        if not isinstance(raw_items, list) or not raw_items:
-            raise RuntimeError("items are required")
-        if not isinstance(provider_config, dict):
-            raise RuntimeError("providerConfig is required")
-
-        max_items = max(
-            1,
-            min(
-                len(raw_items),
-                round(
-                    daily_limit
-                    if isinstance(daily_limit, (int, float))
-                    else len(raw_items)
-                ),
-            ),
-        )
-        items = [item for item in raw_items[:max_items] if isinstance(item, dict)]
-        task_steps: list[dict[str, Any]] = []
-        sent = 0
-        skipped = 0
-        failed = 0
-        final_states: list[str] = []
-
-        for item in items:
-            target_name = str(item.get("targetName") or "").strip() or str(
-                item.get("targetUrl") or ""
-            ).strip() or "LinkedIn profile"
-            target_url = str(item.get("targetUrl") or "").strip()
-            task_steps.append(
-                {
-                    "title": f"Connect with {target_name}",
-                    "status": "pending",
-                    **({"pageUrl": target_url} if target_url else {}),
-                }
-            )
-
-        self.state.metadata.update(
-            {
-                "workflowName": "LinkedInConnectBatchWorkflow",
-                "batchType": "linkedin_connect",
-                "itemCount": len(items),
-                "sent": 0,
-                "skipped": 0,
-                "failed": 0,
-                "taskSteps": task_steps,
-            }
-        )
-
-        for index, item in enumerate(items):
-            self.update_status("running")
-            step = task_steps[index]
-            step["status"] = "running"
-            step["retryCount"] = 0
-            self.state.metadata["taskSteps"] = task_steps
-            target_url = str(item.get("targetUrl") or "").strip()
-            if target_url:
-                self.state.metadata["latestPageUrl"] = target_url
-
-            item_result: dict[str, Any] | None = None
-            item_error: str | None = None
-            max_attempts = 2
-
-            for attempt in range(1, max_attempts + 1):
-                step["retryCount"] = attempt - 1
-                self.state.metadata["taskSteps"] = task_steps
-                try:
-                    item_result = await _tw.execute_activity(
-                        "execute_linkedin_connect",
-                        args=[item, provider_config],
-                        start_to_close_timeout=timedelta(minutes=30),
-                        heartbeat_timeout=timedelta(seconds=120),
-                        retry_policy=RetryPolicy(
-                            initial_interval=timedelta(seconds=60),
-                            maximum_interval=timedelta(minutes=5),
-                            maximum_attempts=5,
-                        ),
-                    )
-                    break
-                except Exception as error:
-                    item_error = normalize_error_message(
-                        error
-                        if isinstance(error, Exception)
-                        else Exception(str(error))
-                    )
-                    if attempt >= max_attempts:
-                        break
-                    await asyncio.sleep(human_delay(1800) / 1000)
-
-                if item_result is None:
-                    failed += 1
-                    step["status"] = "failed"
-                    step["lastError"] = item_error or "LinkedIn connect item failed."
-                    final_states.append("failed")
-                    self.state.metadata["failed"] = failed
-                    self.state.metadata["taskSteps"] = task_steps
-                    continue
-
-                final_state = str(item_result.get("finalState") or "").strip() or "failed"
-                final_states.append(final_state)
-                item_summary = str(item_result.get("summary") or "").strip()
-                preserve_page = bool(item_result.get("preservePage"))
-                if preserve_page and target_url:
-                    self.state.metadata["latestPageUrl"] = target_url
-
-                outcome = str(item_result.get("outcome") or "").strip()
-                if outcome == "sent":
-                    sent += 1
-                    step["status"] = "completed"
-                elif outcome == "skipped":
-                    skipped += 1
-                    step["status"] = "skipped"
-                    step["skipReason"] = item_summary or final_state
-                else:
-                    failed += 1
-                    step["status"] = "failed"
-                    step["lastError"] = item_summary or final_state
-
-                if item_summary:
-                    step["resultSummary"] = item_summary
-
-                self.state.metadata["sent"] = sent
-                self.state.metadata["skipped"] = skipped
-                self.state.metadata["failed"] = failed
-                self.state.metadata["taskSteps"] = task_steps
-
-                await asyncio.sleep(human_delay(2200) / 1000)
-
-        summary_parts = [
-            f"LinkedIn connect batch finished for {len(items)} target{'s' if len(items) != 1 else ''}.",
-            f"Sent: {sent}.",
-        ]
-        if skipped > 0:
-            summary_parts.append(f"Skipped: {skipped}.")
-        if failed > 0:
-            summary_parts.append(f"Failed: {failed}.")
-
-        metadata = {
-            "workflowName": "LinkedInConnectBatchWorkflow",
-            "batchType": "linkedin_connect",
-            "itemCount": len(items),
-            "sent": sent,
-            "skipped": skipped,
-            "failed": failed,
-            "finalStates": final_states,
-            "taskSteps": task_steps,
-        }
-        latest_page_url = str(self.state.metadata.get("latestPageUrl") or "").strip()
-        if latest_page_url:
-            metadata["finalUrl"] = latest_page_url
-
-        return WorkflowResult(
-            value={
-                "summary": " ".join(summary_parts),
-                "metadata": {
-                    "kind": "execute_task_batch",
-                    **metadata,
-                },
-            },
-            metadata=metadata,
-        )
-
-
-class BrowserTaskActivities:
-    """Temporal activities that wrap the entire browser task execution.
-
-    By making the full LLM-loop + all MCP tool calls a single Temporal activity,
-    individual DOM snapshots (50-100 KB each) are never written to the Temporal
-    workflow history.  Only the final small JSON result is persisted, keeping
-    history well under the 512 KB per-payload limit.
-    """
-
-    def __init__(self, runtime: "PythonBrowserRuntime") -> None:
-        self._runtime = runtime
-
-    async def execute_browser_task(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Run one complete browser task (LLM loop + all tool calls) as a single activity."""
-        try:
-            from temporalio import activity as _temporal_activity
-            _temporal_activity.heartbeat("browser task running")
-        except Exception:
-            pass
-        # Periodic heartbeat so Temporal knows the activity is alive during long tasks
-        heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-        try:
-            return await self._runtime.execute_generic_browser_task_once(payload)
-        finally:
-            heartbeat_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await heartbeat_task
-
-    async def execute_linkedin_connect(
-        self,
-        item: dict[str, Any],
-        provider_config: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Run one LinkedIn connect operation as a single activity."""
-        try:
-            from temporalio import activity as _temporal_activity
-            _temporal_activity.heartbeat("linkedin connect running")
-        except Exception:
-            pass
-        heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-        try:
-            return await self._runtime.execute_linkedin_connect_item(item, provider_config)
-        finally:
-            heartbeat_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await heartbeat_task
-
-    @staticmethod
-    async def _heartbeat_loop() -> None:
-        while True:
-            await asyncio.sleep(30)
-            try:
-                from temporalio import activity as _temporal_activity
-                _temporal_activity.heartbeat("browser task in progress")
-            except Exception:
-                break
-
-
 class PythonBrowserRuntime:
     def __init__(self, agent: Agent | None, app: MCPApp | None = None):
         self.agent = agent
         self.app = app
-        self._generic_task_workflow_cls: type[Workflow[dict[str, Any]]] | None = None
-        self._generic_queue_workflow_cls: type[Workflow[dict[str, Any]]] | None = None
-        self._linkedin_connect_batch_workflow_cls: (
-            type[Workflow[dict[str, Any]]] | None
-        ) = None
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        self._cancelled = True
 
     def require_agent(self) -> Agent:
         if self.agent is None:
             raise RuntimeError("A live browser agent is not available in this runtime.")
         return self.agent
-
-    @asynccontextmanager
-    async def workflow_attempt_runtime(self):
-        if self.agent is not None:
-            yield self
-            return
-        if self.app is None:
-            raise RuntimeError("Workflow browser execution requires an initialized app.")
-
-        agent = Agent(
-            name="chrome_runtime_workflow",
-            server_names=["chrome-devtools"],
-            context=self.app.context,
-        )
-        async with agent:
-            yield PythonBrowserRuntime(agent, app=self.app)
-
-    @asynccontextmanager
-    async def persistent_workflow_runtime(self):
-        """Creates ONE agent for a multi-item workflow (queue/batch).
-        Reusing the same MCP connection across items avoids repeated Chrome
-        auto-connect modals and reconnect overhead."""
-        if self.agent is not None:
-            yield self
-            return
-        if self.app is None:
-            raise RuntimeError("Workflow browser execution requires an initialized app.")
-
-        agent = Agent(
-            name="chrome_runtime_workflow",
-            server_names=["chrome-devtools"],
-            context=self.app.context,
-        )
-        async with agent:
-            yield PythonBrowserRuntime(agent, app=self.app)
 
     async def call_tool(
         self,
@@ -1954,85 +870,6 @@ class PythonBrowserRuntime:
         llm.instruction = instruction
         return llm, provider, model
 
-    def create_generic_task_orchestrator(
-        self,
-        *,
-        provider: str,
-        model: str,
-        system_prompt: str,
-    ) -> Any:
-        browser_operator_instruction = "\n\n".join(
-            [
-                "You are the browser operator worker for Chrome DevTools MCP tasks.",
-                "Use Chrome DevTools MCP tools only.",
-                "Inspect the page tree before interacting and verify the page after each major step.",
-                "Do not stop at a plan when the objective explicitly asks for end-to-end browser action.",
-                "Return concise factual results for each subtask.",
-                f"Task-specific runtime instructions:\n{system_prompt}",
-            ]
-        )
-
-        return create_orchestrator(
-            available_agents=[
-                AgentSpec(
-                    name="browser_operator",
-                    instruction=browser_operator_instruction,
-                    server_names=["chrome-devtools"],
-                )
-            ],
-            plan_type="iterative",
-            provider=provider,
-            model=model or None,
-            overrides=build_generic_orchestrator_overrides(),
-            name="browser_task_orchestrator",
-            context=self.require_agent().context,
-        )
-
-    def create_generic_task_workflow_class(
-        self,
-    ) -> type[Workflow[dict[str, Any]]] | None:
-        if self._generic_task_workflow_cls is not None:
-            return self._generic_task_workflow_cls
-        if self.app is None:
-            return None
-        self._generic_task_workflow_cls = _register_runtime_workflow_class(
-            runtime=self,
-            app=self.app,
-            workflow_name="GenericBrowserTaskWorkflow",
-            base_cls=GenericBrowserTaskWorkflowBase,
-        )
-        return self._generic_task_workflow_cls
-
-    def create_generic_queue_workflow_class(
-        self,
-    ) -> type[Workflow[dict[str, Any]]] | None:
-        if self._generic_queue_workflow_cls is not None:
-            return self._generic_queue_workflow_cls
-        if self.app is None:
-            return None
-        self._generic_queue_workflow_cls = _register_runtime_workflow_class(
-            runtime=self,
-            app=self.app,
-            workflow_name="GenericBrowserQueueWorkflow",
-            base_cls=GenericBrowserQueueWorkflowBase,
-        )
-        return self._generic_queue_workflow_cls
-
-    def create_linkedin_connect_batch_workflow_class(
-        self,
-    ) -> type[Workflow[dict[str, Any]]] | None:
-        if self._linkedin_connect_batch_workflow_cls is not None:
-            return self._linkedin_connect_batch_workflow_cls
-        if self.app is None:
-            return None
-        self._linkedin_connect_batch_workflow_cls = _register_runtime_workflow_class(
-            runtime=self,
-            app=self.app,
-            workflow_name="LinkedInConnectBatchWorkflow",
-            base_cls=LinkedInConnectBatchWorkflowBase,
-        )
-        return self._linkedin_connect_batch_workflow_cls
-
     async def run_agent_json_task(
         self,
         *,
@@ -2197,159 +1034,509 @@ class PythonBrowserRuntime:
             "workItems": work_items,
         }
 
-    async def execute_generic_browser_task_once(
-        self, payload: dict[str, Any]
+    def _emit_progress(self, event: dict[str, Any]) -> None:
+        print(json.dumps({"__progress__": True, **event}), flush=True)
+
+    async def _take_planning_snapshot(self) -> str:
+        """Take a live DOM snapshot to ground the plan in reality."""
+        try:
+            result = await self.call_tool("take_snapshot", trace=False)
+            text = tool_result_text(result).strip()
+            return text[:4000] if text else ""
+        except Exception:
+            return ""
+
+    async def _get_actual_selected_url(self) -> str:
+        """Query Chrome for the URL of the currently selected page (ground truth)."""
+        try:
+            pages = await self.list_pages(trace=False)
+            selected = next((p for p in pages if p.get("selected")), pages[0] if pages else None)
+            return str(selected.get("url") or "").strip() if selected else ""
+        except Exception:
+            return ""
+
+    def _build_plan_prompt(
+        self, payload: dict[str, Any], live_snapshot: str = ""
+    ) -> str:
+        goal = str(payload.get("goal") or "").strip()
+        page_url = str(payload.get("pageUrl") or "").strip()
+        platform_hint = str(payload.get("platformHint") or "").strip()
+        page_context = str(payload.get("pageContext") or "").strip()
+        user_context = str(payload.get("userContext") or "").strip()
+        resume_context = str(payload.get("resumeContext") or "").strip()
+        site_experience_context = str(payload.get("siteExperienceContext") or "").strip()
+        work_items = payload.get("workItems")
+        field_target = payload.get("fieldTarget")
+        structured = payload.get("structured")
+        scanned_candidates = payload.get("scannedCandidates")
+        resume_file = payload.get("resumeFile")
+
+        # Build ordered context sections — most important first
+        sections: list[str] = []
+
+        # Live snapshot is the ground truth; stale pageContext is last resort
+        if live_snapshot:
+            sections.append(f"=== LIVE PAGE STATE ===\n{live_snapshot[:3500]}")
+        elif page_context:
+            sections.append(f"=== PAGE CONTEXT (stale — no live snapshot available) ===\n{page_context[:400]}")
+
+        # User identity / profile — always first so it's never truncated
+        if user_context:
+            sections.append(f"=== USER CONTEXT ===\n{user_context[:800]}")
+
+        # Target field (form-filling tasks)
+        if isinstance(field_target, dict):
+            ft_lines = ["=== TARGET FIELD ==="]
+            ftype = str(field_target.get("fieldType") or "").strip()
+            selector = str(field_target.get("selector") or "").strip()
+            char_limit = field_target.get("charLimit")
+            if ftype:
+                ft_lines.append(f"Field type: {ftype}")
+            if selector:
+                ft_lines.append(f"CSS selector: {selector}")
+            if char_limit:
+                ft_lines.append(f"Character limit: {char_limit}")
+            sections.append("\n".join(ft_lines))
+
+        # Pre-extracted structured form data (huge signal for job applications)
+        if isinstance(structured, dict) and structured:
+            sections.append(
+                f"=== PRE-EXTRACTED FORM DATA ===\n"
+                f"{json.dumps(structured, ensure_ascii=True)[:1200]}"
+            )
+
+        # Scan targets (LinkedIn profile lists, etc.)
+        if isinstance(scanned_candidates, list) and scanned_candidates:
+            sections.append(
+                f"=== SCAN TARGETS ===\n"
+                f"{json.dumps(scanned_candidates[:8], ensure_ascii=True)[:1200]}"
+            )
+
+        # Work item batch
+        if isinstance(work_items, list) and work_items:
+            item_lines: list[str] = []
+            for item in work_items[:10]:
+                if isinstance(item, dict):
+                    title = str(item.get("title") or item.get("targetName") or "").strip()
+                    url = str(item.get("targetUrl") or item.get("pageUrl") or "").strip()
+                    goal_hint = str(item.get("itemGoal") or "").strip()
+                    if title or url:
+                        entry = f"- {title}"
+                        if url:
+                            entry += f" ({url})"
+                        if goal_hint:
+                            entry += f" → {goal_hint}"
+                        item_lines.append(entry)
+            if item_lines:
+                sections.append(
+                    f"=== WORK ITEMS ({len(work_items)} total) ===\n" + "\n".join(item_lines)
+                )
+
+        # Resume file hint (job application tasks)
+        if isinstance(resume_file, dict) and resume_file.get("base64"):
+            resume_name = str(resume_file.get("name") or "resume.pdf").strip()
+            sections.append(
+                f"=== RESUME FILE ===\n"
+                f"User's resume ({resume_name}) is available. "
+                f"Include a dedicated upload step if the task involves a file input."
+            )
+
+        # Previous run context (resumed tasks)
+        if resume_context:
+            sections.append(f"=== PREVIOUS RUN CONTEXT ===\n{resume_context[:600]}")
+
+        # Learned patterns for this site
+        if site_experience_context:
+            sections.append(f"=== SITE EXPERIENCE (what has worked here before) ===\n{site_experience_context[:600]}")
+
+        context_block = "\n\n".join(sections)
+        page_header = page_url or "(unknown)"
+        if platform_hint:
+            page_header += f"  [platform: {platform_hint}]"
+
+        return f"""You are a planning agent. Produce a concrete, executable step-by-step plan.
+You are NOT executing — a separate executor runs each step with up to 15 tool calls.
+
+=== GOAL ===
+{goal}
+Current page: {page_header}
+
+{context_block}
+
+=== PLANNING RULES ===
+1. GROUNDED — Every step must reference exact element names, button labels, or URLs visible in the live snapshot. Never invent or guess UI elements.
+2. BOUNDED — Each step should be completable in ~15 LLM tool calls: one focused action + verification. Don't bundle unrelated actions.
+3. SPECIFIC — Step descriptions must include success criteria: what the executor should see after acting ("confirm cart shows 1 item", "verify URL changed to /checkout").
+4. CRITICAL — Mark critical:true if failure should abort the whole task. Mark critical:false for optional verifications or nice-to-have steps.
+5. CROSS-DOMAIN — If the task requires navigating to a different site or domain, make "Navigate to <URL>" an explicit step.
+6. OBSTACLES FIRST — If the snapshot shows a cookie banner, GDPR dialog, modal overlay, or login wall, the first step must handle it before any other action.
+7. FORM GROUPING — Group related form fields into one step. Do NOT create one step per field (e.g., "Fill personal details" covers name + email + phone).
+8. BATCH ITEMS — For work item lists, create one step per item (up to 8 max). Remaining items continue via progress.
+9. RESUME AWARENESS — If PREVIOUS RUN CONTEXT is present, check what was already completed and skip those steps.
+10. STEP COUNT — Simple task: 1–3 steps. Multi-page task: 4–6 steps. Complex batch: up to 8 steps. Never exceed 8.
+
+=== RETURN FORMAT ===
+Return ONLY valid JSON — no markdown, no explanation:
+{{"steps": [{{"title": "≤60 chars, action-oriented", "description": "specific instructions + success criteria the executor must verify", "critical": true}}]}}"""
+
+    def _build_step_prompt(
+        self,
+        step: dict[str, Any],
+        payload: dict[str, Any],
+        completed: list[dict[str, Any]],
+        all_steps: list[dict[str, Any]],
+        index: int,
+        current_url: str,
+        resume_tmp_path: str | None = None,
+    ) -> str:
+        goal = str(payload.get("goal") or "").strip()
+        user_context = str(payload.get("userContext") or "").strip()
+        field_target = payload.get("fieldTarget")
+        structured = payload.get("structured")
+
+        # Build completed-step history (rolling window: full observations for last 2 steps only)
+        completed_lines: list[str] = []
+        total_done = len(completed)
+        for ci, c in enumerate(completed):
+            s = c.get("step", {})
+            r = c.get("result") or {}
+            summary = str(r.get("summary") or "done").strip()
+            verified = r.get("verified")
+            tag = " [✓]" if verified is True else (" [!]" if verified is False else "")
+            is_recent = ci >= total_done - 2
+            observations = str(r.get("observations") or "").strip() if is_recent else ""
+            line = f"  ✓ {s.get('title', '')}: {summary}{tag}"
+            if observations:
+                line += f"\n    → {observations[:220]}"
+            completed_lines.append(line)
+        completed_section = (
+            "\n=== WHAT HAPPENED SO FAR ===\n"
+            + "\n".join(completed_lines)
+            if completed_lines else ""
+        )
+
+        remaining_lines: list[str] = []
+        for j, s in enumerate(all_steps):
+            if j > index:
+                remaining_lines.append(f"  {j + 1}. {s.get('title', '')}")
+        remaining_section = (
+            "\n=== UPCOMING STEPS (awareness only — do NOT execute these) ===\n"
+            + "\n".join(remaining_lines)
+            if remaining_lines else ""
+        )
+
+        # Extra context for the executor
+        extra_parts: list[str] = []
+        if user_context:
+            extra_parts.append(f"User context:\n{user_context[:600]}")
+
+        if isinstance(field_target, dict):
+            ft_lines: list[str] = ["Target field:"]
+            ftype = str(field_target.get("fieldType") or "").strip()
+            selector = str(field_target.get("selector") or "").strip()
+            char_limit = field_target.get("charLimit")
+            if ftype:
+                ft_lines.append(f"  type: {ftype}")
+            if selector:
+                ft_lines.append(f"  selector: {selector}")
+            if char_limit:
+                ft_lines.append(f"  char limit: {char_limit}")
+            extra_parts.append("\n".join(ft_lines))
+
+        if isinstance(structured, dict) and structured:
+            extra_parts.append(
+                f"Pre-extracted form data (use these values when filling fields):\n"
+                f"{json.dumps(structured, ensure_ascii=True)[:800]}"
+            )
+
+        if resume_tmp_path:
+            resume_name = str(payload.get("resumeFile", {}).get("name") or "resume.pdf") if isinstance(payload.get("resumeFile"), dict) else "resume.pdf"
+            extra_parts.append(
+                f"Resume file: '{resume_name}' is saved at: {resume_tmp_path}\n"
+                f"For file upload inputs: use the upload_file tool or set_file_input_files CDP method with path '{resume_tmp_path}'."
+            )
+
+        extra_context = ("\n\n" + "\n\n".join(extra_parts)) if extra_parts else ""
+
+        return f"""Execute ONLY this one step. Use Chrome DevTools MCP tools.
+
+=== YOUR STEP ===
+Step {index + 1} of {len(all_steps)}: {step.get("title", "")}
+{step.get("description", "")}
+
+=== CONTEXT ===
+Overall goal: {goal}
+Current browser URL: {current_url or "(call take_snapshot to confirm)"}{extra_context}{completed_section}{remaining_section}
+
+=== EXECUTION RULES ===
+1. NAVIGATE FIRST (most important) — If this step requires going to a specific URL or site (e.g., "Navigate to Amazon", "Open google.com"), call navigate_page IMMEDIATELY as your very first action. Do NOT call take_snapshot or list_pages first — the current page is irrelevant and looking at it wastes iterations. After navigate_page completes, then take a snapshot to verify you arrived.
+2. SNAPSHOT BEFORE INTERACTION — For steps that interact with a page (click, fill, search), call take_snapshot first to see the live DOM before acting.
+3. OBSTACLES — If you see a cookie banner, GDPR dialog, or modal overlay: dismiss it first, then continue.
+4. FORM FILLING — Use fill() for input fields and textareas; fall back to type_text() only if fill() has no effect.
+5. VERIFY — After every action, call take_snapshot to confirm the change took effect.
+6. RETRY — If an element isn't found: scroll down, re-snapshot, look for alternative selectors.
+7. SINGLE STEP — Do NOT proceed to the next step. Execute only what is described above.
+8. NO INFINITE LOOPS — If you've called take_snapshot or list_pages more than 3 times without performing a navigation or click, STOP observing and ACT: navigate to the correct URL or return status "failed".
+
+=== RETURN ===
+Return ONLY valid JSON (no markdown):
+{{"summary": "one sentence: what was accomplished", "status": "completed" or "failed", "verified": true or false, "observations": "exactly what you saw — element labels, field names, URL, values, any site quirks; be specific so subsequent steps can use this", "finalUrl": "current URL if this step navigated to a new page"}}
+
+If this step cannot be completed on the current page: return status "failed" with a clear reason in summary."""
+
+    async def _generate_plan(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        provider_config = payload.get("providerConfig")
+        if not isinstance(provider_config, dict):
+            raise RuntimeError("providerConfig is required")
+
+        live_snapshot = await self._take_planning_snapshot()
+        log_runtime(f"[plan] snapshot={'yes' if live_snapshot else 'no'} len={len(live_snapshot)}")
+
+        llm, _provider, model = await self.attach_augmented_llm(
+            provider_config,
+            build_effective_system_prompt(BASE_AGENT_SYSTEM_PROMPT, None),
+        )
+        prompt = self._build_plan_prompt(payload, live_snapshot)
+        # max_iterations=3: snapshot is embedded but some LLMs (Gemini) still try to
+        # call take_snapshot first; give them 2 extra iterations to respond with JSON.
+        response = await llm.generate_str(
+            prompt,
+            RequestParams(
+                model=model or None,
+                max_iterations=3,
+                maxTokens=900,
+                temperature=0.1,
+                use_history=False,
+            ),
+        )
+        log_runtime(f"[plan] raw_response={truncate_text(response, 400)}")
+        try:
+            parsed = extract_json_payload(response)
+        except Exception:
+            # Repair pass: LLM returned narrative — ask it to convert to JSON.
+            goal = str(payload.get("goal") or "").strip()
+            repair_prompt = (
+                f"The previous response did not return valid JSON.\n\n"
+                f"Goal: {goal}\n"
+                f"Previous response: {json.dumps(response[:1500], ensure_ascii=True)}\n\n"
+                f"Return ONLY this JSON (no markdown, no explanation):\n"
+                f'{"{"}"steps": [{{"title": "≤60 chars", "description": "specific instructions", "critical": true}}]{"}"}\n\n'
+                f"Use 2-6 steps. Each title must start with a verb (Navigate, Search, Click, Fill, Open, Verify)."
+            )
+            repair_response = await llm.generate_str(
+                repair_prompt,
+                RequestParams(
+                    model=model or None,
+                    max_iterations=2,
+                    maxTokens=600,
+                    temperature=0,
+                    use_history=False,
+                ),
+            )
+            try:
+                parsed = extract_json_payload(repair_response)
+            except Exception:
+                return [{"title": "Complete the requested task", "description": str(payload.get("goal") or ""), "critical": True}]
+        steps = parsed.get("steps") if isinstance(parsed, dict) else parsed if isinstance(parsed, list) else []
+        if not isinstance(steps, list) or not steps:
+            return [{"title": "Complete the requested task", "description": str(payload.get("goal") or ""), "critical": True}]
+        return [s for s in steps if isinstance(s, dict)][:8]
+
+    async def _execute_step(
+        self,
+        step: dict[str, Any],
+        payload: dict[str, Any],
+        completed: list[dict[str, Any]],
+        all_steps: list[dict[str, Any]],
+        index: int,
+        current_url: str,
+        resume_tmp_path: str | None = None,
     ) -> dict[str, Any]:
         provider_config = payload.get("providerConfig")
         if not isinstance(provider_config, dict):
             raise RuntimeError("providerConfig is required")
 
-        page_url = str(payload.get("pageUrl") or "").strip()
-        focused_page: dict[str, Any] | None = None
-        if page_url:
-            focused_page = await self.focus_or_open_page(page_url)
-            await self.wait_for_page_ready(focused_page["pageId"], 15000)
+        # Ground truth URL from Chrome — more reliable than tracked current_url,
+        # which may be stale if the previous step navigated without setting finalUrl.
+        actual_url = await self._get_actual_selected_url() or current_url
 
-        agent_result = await self.run_agent_json_task(
-            provider_config=provider_config,
-            task_label="generic_browser_task",
-            system_prompt=build_effective_system_prompt(
+        # Pre-navigation guard: if the step explicitly targets a URL and the browser
+        # is currently on a different domain, navigate there BEFORE calling the LLM.
+        # This prevents observation-loop failures where weak models (Gemini) keep
+        # calling take_snapshot / list_pages instead of navigating.
+        target_url = _extract_step_target_url(step, actual_url)
+        if target_url:
+            pages = await self.list_pages(trace=False)
+            page_id = pages[0]["pageId"] if pages else None
+            if page_id is not None:
+                log_runtime(f"[step] pre-navigate url={target_url}")
+                try:
+                    await self.navigate_page(page_id, target_url)
+                    actual_url = target_url
+                except Exception as nav_err:
+                    log_runtime(f"[step] pre-navigate failed: {nav_err}")
+
+        llm, _provider, model = await self.attach_augmented_llm(
+            provider_config,
+            build_effective_system_prompt(
                 BASE_AGENT_SYSTEM_PROMPT,
                 str(payload.get("systemPrompt") or "").strip() or None,
             ),
-            user_prompt=build_general_task_prompt(payload),
-            max_iterations=100,
-            max_tokens=1600,
+        )
+        # The executor is responsible for ALL navigation via tool calls.
+        # We do NOT pre-navigate here — a previous step may have intentionally
+        # landed on a different domain (e.g., LinkedIn → Amazon).
+        prompt = self._build_step_prompt(
+            step, payload, completed, all_steps, index, actual_url,
+            resume_tmp_path=resume_tmp_path,
         )
 
-        status = str(agent_result.get("status") or "").strip().lower() or "failed"
-        summary = str(agent_result.get("summary") or "").strip()
-        if not summary:
-            summary = "The Chrome MCP agent finished without returning a usable summary."
-
-        if status == "failed":
-            raise RuntimeError(summary)
-
-        metadata: dict[str, Any] = {
-            "kind": "execute_agent_task",
-            "status": status,
-            "executionMode": str(agent_result.get("_executionMode") or "").strip()
-            or "direct_llm",
-        }
-        if focused_page:
-            metadata["pageId"] = focused_page["pageId"]
-        final_url = str(agent_result.get("finalUrl") or "").strip()
-        if final_url:
-            metadata["finalUrl"] = final_url
-        plan_steps = agent_result.get("_planSteps")
-        if isinstance(plan_steps, list) and plan_steps:
-            metadata["taskSteps"] = plan_steps
-
-        return {
-            "summary": summary,
-            "metadata": metadata,
-        }
-
-    async def start_generic_browser_task_workflow(
-        self, payload: dict[str, Any]
-    ) -> dict[str, Any]:
-        workflow_cls = self.create_generic_task_workflow_class()
-        if workflow_cls is None:
-            raise RuntimeError("Generic browser task workflow is not available.")
-
-        if self.app is None:
-            raise RuntimeError("Workflow registry is not available in the runtime context.")
-        workflow = workflow_cls(context=self.app.context)
-        execution = await workflow.run_async(
-            dict(payload),
-            __mcp_agent_workflow_id=f"generic_browser_task_{uuid.uuid4().hex}",
+        response = await llm.generate_str(
+            prompt,
+            RequestParams(
+                model=model or None,
+                max_iterations=15,
+                maxTokens=1200,
+                temperature=0.1,
+                use_history=False,
+            ),
         )
-        return {
-            "workflowId": execution.workflow_id,
-            "runId": execution.run_id,
-        }
-
-    async def start_generic_browser_queue_workflow(
-        self, payload: dict[str, Any]
-    ) -> dict[str, Any]:
-        workflow_cls = self.create_generic_queue_workflow_class()
-        if workflow_cls is None:
-            raise RuntimeError("Generic browser queue workflow is not available.")
-
-        if self.app is None:
-            raise RuntimeError("Workflow registry is not available in the runtime context.")
-        workflow = workflow_cls(context=self.app.context)
-        execution = await workflow.run_async(
-            dict(payload),
-            __mcp_agent_workflow_id=f"generic_browser_queue_{uuid.uuid4().hex}",
-        )
-        return {
-            "workflowId": execution.workflow_id,
-            "runId": execution.run_id,
-        }
-
-    async def start_linkedin_connect_batch_workflow(
-        self, payload: dict[str, Any]
-    ) -> dict[str, Any]:
-        workflow_cls = self.create_linkedin_connect_batch_workflow_class()
-        if workflow_cls is None:
-            raise RuntimeError("LinkedIn connect batch workflow is not available.")
-
-        if self.app is None:
-            raise RuntimeError("Workflow registry is not available in the runtime context.")
-        workflow = workflow_cls(context=self.app.context)
-        execution = await workflow.run_async(
-            dict(payload),
-            __mcp_agent_workflow_id=f"linkedin_connect_batch_{uuid.uuid4().hex}",
-        )
-        return {
-            "workflowId": execution.workflow_id,
-            "runId": execution.run_id,
-        }
-
-    async def get_workflow_status(
-        self, *, workflow_id: str | None = None, run_id: str | None = None
-    ) -> dict[str, Any] | None:
-        registry = getattr(self.app.context if self.app is not None else None, "workflow_registry", None)
-        if registry is None:
-            raise RuntimeError("Workflow registry is not available in the runtime context.")
-        return await registry.get_workflow_status(
-            run_id=run_id,
-            workflow_id=workflow_id,
-        )
-
-    async def resume_workflow(
-        self,
-        *,
-        workflow_id: str | None = None,
-        run_id: str | None = None,
-        signal_name: str | None = "resume",
-        payload: Any | None = None,
-    ) -> bool:
-        registry = getattr(self.app.context if self.app is not None else None, "workflow_registry", None)
-        if registry is None:
-            raise RuntimeError("Workflow registry is not available in the runtime context.")
-        return bool(
-            await registry.resume_workflow(
-                run_id=run_id,
-                workflow_id=workflow_id,
-                signal_name=signal_name,
-                payload=payload,
+        try:
+            result = extract_json_payload(response)
+        except Exception:
+            # LLM narrated instead of returning JSON — run a finalization pass.
+            page_state = await self.capture_selected_page_state()
+            repair_prompt = build_json_finalization_prompt(
+                task_label=step.get("title", "step"),
+                original_response=response,
+                page_url=str(page_state.get("pageUrl") or "").strip() or None,
+                page_title=str(page_state.get("pageTitle") or "").strip() or None,
+                page_snapshot=str(page_state.get("pageSnapshot") or "").strip() or None,
             )
+            repair_response = await llm.generate_str(
+                repair_prompt,
+                RequestParams(
+                    model=model or None,
+                    max_iterations=2,
+                    maxTokens=500,
+                    temperature=0,
+                    use_history=False,
+                ),
+            )
+            try:
+                result = extract_json_payload(repair_response)
+            except Exception:
+                result = {"summary": response.strip()[:200] or "Step executed.", "status": "completed"}
+        if str(result.get("status") or "").strip().lower() == "failed":
+            raise RuntimeError(str(result.get("summary") or "Step failed"))
+
+        # Read the actual Chrome URL after the step — more reliable than the
+        # LLM's optional finalUrl which may be omitted for non-navigation steps.
+        post_url = await self._get_actual_selected_url()
+        if post_url:
+            result["_actualFinalUrl"] = post_url
+        return result
+
+    async def execute_with_explicit_plan(self, payload: dict[str, Any]) -> dict[str, Any]:
+        run_id = str(payload.get("runId") or "").strip()
+        self._cancelled = False
+
+        # Write the resume to a temp file once — pass the path to every step.
+        # Avoids re-decoding base64 on every step that might need it.
+        resume_tmp_path: str | None = None
+        resume_file = payload.get("resumeFile")
+        if isinstance(resume_file, dict) and resume_file.get("base64"):
+            resume_tmp_path = write_resume_to_temp(resume_file)
+
+        self._emit_progress({"event": "planning", "runId": run_id})
+        plan_steps = await self._generate_plan(payload)
+        self._emit_progress({
+            "event": "plan_ready",
+            "runId": run_id,
+            "steps": [
+                {"title": s.get("title", ""), "description": s.get("description", "")}
+                for s in plan_steps
+            ],
+        })
+
+        completed: list[dict[str, Any]] = []
+        current_url = str(payload.get("pageUrl") or "").strip()
+
+        for i, step in enumerate(plan_steps):
+            if self._cancelled:
+                raise asyncio.CancelledError("Run was cancelled by user")
+
+            self._emit_progress({
+                "event": "step_started", "runId": run_id, "index": i,
+                "title": step.get("title", ""),
+            })
+            step_result: dict[str, Any] | None = None
+            last_error: str | None = None
+
+            for attempt in range(3):
+                if self._cancelled:
+                    raise asyncio.CancelledError("Run was cancelled by user")
+                try:
+                    step_result = await self._execute_step(
+                        step, payload, completed, plan_steps, i, current_url,
+                        resume_tmp_path=resume_tmp_path,
+                    )
+                    last_error = None
+                    break
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    last_error = str(exc)
+                    if attempt < 2:
+                        self._emit_progress({
+                            "event": "step_retrying", "runId": run_id, "index": i,
+                            "error": last_error, "attempt": attempt + 1,
+                        })
+                        await asyncio.sleep(2 ** attempt * 2)
+
+            if last_error:
+                is_critical = bool(step.get("critical", True))
+                self._emit_progress({
+                    "event": "step_failed", "runId": run_id, "index": i,
+                    "error": last_error, "skipped": not is_critical,
+                })
+                if is_critical:
+                    raise RuntimeError(f"Step '{step.get('title', '')}' failed: {last_error}")
+                step_result = {"summary": f"Skipped: {last_error}", "status": "skipped"}
+            else:
+                # Prefer actual Chrome URL over the LLM's optional finalUrl field.
+                step_actual_url = (
+                    str(step_result.get("_actualFinalUrl") or step_result.get("finalUrl") or "")
+                    if step_result else ""
+                )
+                if step_actual_url:
+                    current_url = step_actual_url
+                verified = step_result.get("verified") if step_result else None
+                observations = str(step_result.get("observations") or "") if step_result else ""
+                self._emit_progress({
+                    "event": "step_completed", "runId": run_id, "index": i,
+                    "summary": str(step_result.get("summary") or "") if step_result else "",
+                    "status": str(step_result.get("status") or "completed") if step_result else "completed",
+                    "verified": verified,
+                    "observations": observations,
+                })
+
+            completed.append({"step": step, "result": step_result})
+
+        step_summaries = [
+            str(c.get("result", {}).get("summary") or "") for c in completed
+            if c.get("result", {}).get("summary") and
+               str(c.get("result", {}).get("status") or "completed") != "skipped"
+        ]
+        overall_summary = (
+            step_summaries[-1] if len(step_summaries) == 1
+            else (" → ".join(step_summaries) if step_summaries else "Task completed.")
         )
 
-    async def cancel_workflow(
-        self, *, workflow_id: str | None = None, run_id: str | None = None
-    ) -> bool:
-        registry = getattr(self.app.context if self.app is not None else None, "workflow_registry", None)
-        if registry is None:
-            raise RuntimeError("Workflow registry is not available in the runtime context.")
-        return bool(
-            await registry.cancel_workflow(
-                run_id=run_id,
-                workflow_id=workflow_id,
-            )
-        )
+        metadata: dict[str, Any] = {"kind": "execute_agent_task", "status": "completed"}
+        if current_url:
+            metadata["finalUrl"] = current_url
+        return {"summary": overall_summary, "metadata": metadata}
 
     async def navigate_to_url(self, payload: dict[str, Any]) -> dict[str, Any]:
         target_url = str(payload.get("targetUrl") or "").strip()
@@ -2605,114 +1792,13 @@ class PythonBrowserRuntime:
         provider_config = payload.get("providerConfig")
         if not isinstance(provider_config, dict):
             raise RuntimeError("providerConfig is required")
-
-        if is_linkedin_profile_connect_goal(payload):
-            target_url = str(payload.get("pageUrl") or "").strip()
-            if not target_url:
-                raise RuntimeError("A LinkedIn profile URL is required for connect tasks.")
-            connect_result = await self.execute_linkedin_connect_item(
-                {
-                    "targetUrl": target_url,
-                    "targetName": extract_linkedin_target_name(payload),
-                    "goal": str(payload.get("goal") or "").strip(),
-                    "pageContext": str(payload.get("pageContext") or "").strip(),
-                    "resumeContext": str(payload.get("resumeContext") or "").strip(),
-                    "siteExperienceContext": str(payload.get("siteExperienceContext") or "").strip(),
-                    "userContext": str(payload.get("userContext") or "").strip(),
-                    "systemPrompt": str(payload.get("systemPrompt") or "").strip(),
-                },
-                provider_config,
-            )
-            if connect_result["outcome"] == "failed":
-                raise RuntimeError(connect_result["summary"])
-
-            return {
-                "summary": connect_result["summary"],
-                "metadata": {
-                    "kind": "execute_agent_task",
-                    "taskType": "linkedin_profile_connect",
-                    "finalState": connect_result["finalState"],
-                    "status": connect_result["outcome"],
-                    "targetUrl": target_url,
-                    "preservedPage": connect_result["preservedPage"],
-                },
-            }
-
-        workflow_cls = self.create_generic_task_workflow_class()
-        if workflow_cls is None:
-            return await self.execute_generic_browser_task_once(payload)
-
-        workflow = workflow_cls(context=self.agent.context)
-        workflow_result = await workflow.run(dict(payload))
-        outcome = workflow_result.value
-        if not isinstance(outcome, dict):
-            raise RuntimeError(
-                "Generic browser task workflow returned an invalid result."
-            )
-
-        metadata = outcome.get("metadata")
-        if isinstance(metadata, dict):
-            workflow_metadata = dict(workflow_result.metadata or {})
-            if workflow_metadata:
-                metadata["workflow"] = workflow_metadata
-        return outcome
-
-
-async def create_temporal_worker(app: MCPApp, runtime: PythonBrowserRuntime) -> Worker:
-    if not isinstance(app.executor, TemporalExecutor):
-        raise RuntimeError("Temporal worker startup requires a TemporalExecutor.")
-
-    await app.executor.ensure_client()
-    temporal_executor._preload_workflow_task_modules(app)
-
-    agent_tasks = AgentTasks(context=app.context)
-    app.workflow_task()(agent_tasks.call_tool_task)
-    app.workflow_task()(agent_tasks.get_capabilities_task)
-    app.workflow_task()(agent_tasks.get_prompt_task)
-    app.workflow_task()(agent_tasks.initialize_aggregator_task)
-    app.workflow_task()(agent_tasks.list_prompts_task)
-    app.workflow_task()(agent_tasks.list_tools_task)
-    app.workflow_task()(agent_tasks.shutdown_aggregator_task)
-
-    system_activities = SystemActivities(context=app.context)
-    app.workflow_task(name="mcp_forward_log")(system_activities.forward_log)
-    app.workflow_task(name="mcp_request_user_input")(system_activities.request_user_input)
-    app.workflow_task(name="mcp_relay_notify")(system_activities.relay_notify)
-    app.workflow_task(name="mcp_relay_request")(system_activities.relay_request)
-
-    # Register browser task activities that use the persistent direct-asyncio agent.
-    # These wrap the entire LLM loop + all MCP tool calls as ONE activity so that
-    # individual DOM snapshots never get written to the Temporal workflow history.
-    browser_activities = BrowserTaskActivities(runtime)
-    app.workflow_task(name="execute_browser_task")(
-        browser_activities.execute_browser_task
-    )
-    app.workflow_task(name="execute_linkedin_connect")(
-        browser_activities.execute_linkedin_connect
-    )
-
-    app._register_global_workflow_tasks()
-
-    task_registry = app.context.task_registry
-    activities = [
-        task_registry.get_activity(name) for name in task_registry.list_activities()
-    ]
-    workflows = app.context.app.workflows.values()
-
-    return Worker(
-        client=app.executor.client,
-        task_queue=app.executor.config.task_queue,
-        activities=activities,
-        workflows=workflows,
-        interceptors=[ContextPropagationInterceptor()],
-    )
+        return await self.execute_with_explicit_plan(payload)
 
 
 async def run_runtime() -> None:
-    workflow_settings = build_settings()
     direct_app = MCPApp(
         name="cheatresume_python_browser_runtime",
-        settings=build_runtime_settings("asyncio"),
+        settings=build_runtime_settings(),
     )
 
     async with direct_app.run():
@@ -2724,261 +1810,55 @@ async def run_runtime() -> None:
 
         async with agent:
             runtime = PythonBrowserRuntime(agent, app=direct_app)
-            temporal_worker: Worker | None = None
-            temporal_worker_task: asyncio.Task[None] | None = None
-            temporal_app: MCPApp | None = None
-            temporal_app_run_context = None
-            workflow_runtime: PythonBrowserRuntime | None = None
-            try:
-                if workflow_settings.execution_engine == "temporal":
-                    temporal_app = MCPApp(
-                        name="cheatresume_python_browser_workflows",
-                        settings=workflow_settings,
-                    )
-                    temporal_app_run_context = temporal_app.run()
-                    await temporal_app_run_context.__aenter__()
-                    workflow_runtime = PythonBrowserRuntime(None, app=temporal_app)
-                    workflow_runtime.create_generic_task_workflow_class()
-                    workflow_runtime.create_generic_queue_workflow_class()
-                    workflow_runtime.create_linkedin_connect_batch_workflow_class()
-                    # Pass the direct asyncio runtime so browser activities use the
-                    # persistent agent (no per-call agent restarts, no history bloat).
-                    temporal_worker = await create_temporal_worker(temporal_app, runtime)
-                    temporal_worker_task = asyncio.create_task(temporal_worker.run())
-                    log_runtime(
-                        f"[temporal-worker] started host={build_temporal_host()} task_queue={temporal_app.executor.config.task_queue}"
-                    )
-                while True:
-                    request_id = "unknown"
-                    try:
-                        if temporal_worker_task is not None and temporal_worker_task.done():
-                            temporal_worker_task.result()
-
-                        while True:
-                            raw_line = await read_request_line()
-                            if raw_line == "":
-                                return
-
-                            line = raw_line.strip()
-                            if line:
-                                break
-
-                        request = json.loads(line)
-                        request_id = str(request.get("id", "unknown"))
-                        method = request.get("method")
-                        args = request.get("args")
-                        if not isinstance(args, dict):
-                            args = {}
-
-                        if method == "shutdown":
-                            write_response(
-                                {"id": request_id, "ok": True, "result": {"ok": True}}
-                            )
+            while True:
+                request_id = "unknown"
+                try:
+                    while True:
+                        raw_line = await read_request_line()
+                        if raw_line == "":
                             return
+                        line = raw_line.strip()
+                        if line:
+                            break
 
-                        if method == "health":
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(await runtime.health()),
-                                }
-                            )
-                            continue
+                    request = json.loads(line)
+                    request_id = str(request.get("id", "unknown"))
+                    method = request.get("method")
+                    args = request.get("args")
+                    if not isinstance(args, dict):
+                        args = {}
 
-                        if method == "derive_browser_work_items":
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await runtime.derive_browser_work_items(args)
-                                    ),
-                                }
-                            )
-                            continue
+                    if method == "shutdown":
+                        write_response({"id": request_id, "ok": True, "result": {"ok": True}})
+                        return
 
-                        if method == "start_generic_browser_task_workflow":
-                            workflow_handler = workflow_runtime or runtime
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await workflow_handler.start_generic_browser_task_workflow(
-                                            args
-                                        )
-                                    ),
-                                }
-                            )
-                            continue
+                    if method == "health":
+                        write_response({"id": request_id, "ok": True, "result": serialize_result(await runtime.health())})
+                        continue
 
-                        if method == "start_generic_browser_queue_workflow":
-                            workflow_handler = workflow_runtime or runtime
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await workflow_handler.start_generic_browser_queue_workflow(
-                                            args
-                                        )
-                                    ),
-                                }
-                            )
-                            continue
+                    if method == "derive_browser_work_items":
+                        write_response({"id": request_id, "ok": True, "result": serialize_result(await runtime.derive_browser_work_items(args))})
+                        continue
 
-                        if method == "start_linkedin_connect_batch_workflow":
-                            workflow_handler = workflow_runtime or runtime
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await workflow_handler.start_linkedin_connect_batch_workflow(
-                                            args
-                                        )
-                                    ),
-                                }
-                            )
-                            continue
+                    if method == "navigate_to_url":
+                        write_response({"id": request_id, "ok": True, "result": serialize_result(await runtime.navigate_to_url(args))})
+                        continue
 
-                        if method == "get_workflow_status":
-                            workflow_handler = workflow_runtime or runtime
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await workflow_handler.get_workflow_status(
-                                            workflow_id=(
-                                                str(args.get("workflowId") or "").strip()
-                                                or None
-                                            ),
-                                            run_id=(
-                                                str(args.get("runId") or "").strip()
-                                                or None
-                                            ),
-                                        )
-                                    ),
-                                }
-                            )
-                            continue
+                    if method == "insert_draft":
+                        write_response({"id": request_id, "ok": True, "result": serialize_result(await runtime.insert_draft(args))})
+                        continue
 
-                        if method == "resume_workflow":
-                            workflow_handler = workflow_runtime or runtime
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await workflow_handler.resume_workflow(
-                                            workflow_id=(
-                                                str(args.get("workflowId") or "").strip()
-                                                or None
-                                            ),
-                                            run_id=(
-                                                str(args.get("runId") or "").strip()
-                                                or None
-                                            ),
-                                            signal_name=(
-                                                str(args.get("signalName") or "").strip()
-                                                or "resume"
-                                            ),
-                                            payload=args.get("payload"),
-                                        )
-                                    ),
-                                }
-                            )
-                            continue
+                    if method == "execute_linkedin_connect_batch":
+                        write_response({"id": request_id, "ok": True, "result": serialize_result(await runtime.execute_linkedin_connect_batch(args))})
+                        continue
 
-                        if method == "cancel_workflow":
-                            workflow_handler = workflow_runtime or runtime
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await workflow_handler.cancel_workflow(
-                                            workflow_id=(
-                                                str(args.get("workflowId") or "").strip()
-                                                or None
-                                            ),
-                                            run_id=(
-                                                str(args.get("runId") or "").strip()
-                                                or None
-                                            ),
-                                        )
-                                    ),
-                                }
-                            )
-                            continue
+                    if method == "execute_agent_task":
+                        write_response({"id": request_id, "ok": True, "result": serialize_result(await runtime.execute_agent_task(args))})
+                        continue
 
-                        if method == "navigate_to_url":
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await runtime.navigate_to_url(args)
-                                    ),
-                                }
-                            )
-                            continue
-
-                        if method == "insert_draft":
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await runtime.insert_draft(args)
-                                    ),
-                                }
-                            )
-                            continue
-
-                        if method == "execute_linkedin_connect_batch":
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await runtime.execute_linkedin_connect_batch(args)
-                                    ),
-                                }
-                            )
-                            continue
-
-                        if method == "execute_agent_task":
-                            write_response(
-                                {
-                                    "id": request_id,
-                                    "ok": True,
-                                    "result": serialize_result(
-                                        await runtime.execute_agent_task(args)
-                                    ),
-                                }
-                            )
-                            continue
-
-                        raise ValueError(f"Unsupported runtime method: {method}")
-                    except Exception as error:
-                        write_response(
-                            {
-                                "id": request_id,
-                                "ok": False,
-                                "error": normalize_error_message(error),
-                            }
-                        )
-            finally:
-                if temporal_worker is not None:
-                    await temporal_worker.shutdown()
-                if temporal_worker_task is not None:
-                    with suppress(asyncio.CancelledError):
-                        await temporal_worker_task
-                if temporal_app_run_context is not None:
-                    await temporal_app_run_context.__aexit__(None, None, None)
+                    raise ValueError(f"Unsupported runtime method: {method}")
+                except Exception as error:
+                    write_response({"id": request_id, "ok": False, "error": normalize_error_message(error)})
 
 
 def main() -> None:

--- a/companion/service.ts
+++ b/companion/service.ts
@@ -163,23 +163,6 @@ function createInitialRunTasks(
   ];
 }
 
-function createRunTasksFromWorkItems(
-  workItems: LocalCompanionBrowserWorkItem[],
-  options?: { firstTaskRunning?: boolean }
-): LocalCompanionRunTask[] {
-  const now = Date.now();
-  return workItems.map((item, index) => ({
-    _id: createTaskId(),
-    title: item.title,
-    status: options?.firstTaskRunning && index === 0 ? "running" : "pending",
-    retryCount: 0,
-    createdAt: now,
-    updatedAt: now,
-    ...(options?.firstTaskRunning && index === 0 ? { startedAt: now } : {}),
-    ...(item.pageUrl ? { pageUrl: item.pageUrl } : {}),
-  }));
-}
-
 const RESUME_GOAL_PATTERN =
   /\b(continue|resume|pick up|keep going|proceed|try again|from where you left off)\b/i;
 
@@ -678,49 +661,6 @@ function coerceRuntimeTaskSteps(
     .filter((item): item is RuntimeTaskStep => item !== null);
 }
 
-function coerceWorkflowStatus(
-  value: unknown
-): {
-  status?: string;
-  running?: boolean;
-  completed?: boolean;
-  error?: string;
-  metadata?: Record<string, unknown>;
-  value?: Record<string, unknown>;
-  state?: Record<string, unknown>;
-} | null {
-  if (!isPlainObject(value)) {
-    return null;
-  }
-
-  const state = isPlainObject(value.state)
-    ? (value.state as Record<string, unknown>)
-    : undefined;
-  const result = isPlainObject(value.result)
-    ? (value.result as Record<string, unknown>)
-    : undefined;
-  const workflowValue =
-    result && isPlainObject(result.value)
-      ? (result.value as Record<string, unknown>)
-      : undefined;
-  const workflowMetadata =
-    result && isPlainObject(result.metadata)
-      ? (result.metadata as Record<string, unknown>)
-      : undefined;
-
-  return {
-    ...(typeof value.status === "string" ? { status: value.status } : {}),
-    ...(typeof value.running === "boolean" ? { running: value.running } : {}),
-    ...(typeof value.completed === "boolean" ? { completed: value.completed } : {}),
-    ...(typeof value.error === "string" && value.error.trim()
-      ? { error: value.error.trim() }
-      : {}),
-    ...(state ? { state } : {}),
-    ...(workflowMetadata ? { metadata: workflowMetadata } : {}),
-    ...(workflowValue ? { value: workflowValue } : {}),
-  };
-}
-
 function buildRunTasksFromRuntimeSteps(args: {
   existingTasks: LocalCompanionRunTask[] | undefined;
   runtimeSteps: RuntimeTaskStep[];
@@ -813,20 +753,6 @@ function isRetryableAgentError(message: string): boolean {
   return true;
 }
 
-function isLinkedInProfileConnectGoal(params: LocalCompanionStartRunParams): boolean {
-  const goal = params.goal.trim().toLowerCase();
-  const platformHint = String(params.platformHint ?? "").trim().toLowerCase();
-  const pageUrl = String(params.pageUrl ?? "").trim().toLowerCase();
-
-  const isLinkedIn = platformHint === "linkedin" || pageUrl.includes("linkedin.com");
-  const isProfile = pageUrl.includes("linkedin.com/in/");
-  const wantsConnect = ["connect", "connection request", "invite", "add a note", "connection note"].some(
-    (phrase) => goal.includes(phrase)
-  );
-
-  return isLinkedIn && isProfile && wantsConnect;
-}
-
 function isTerminalRunStatus(
   status: StoredRunRecord["status"] | LocalCompanionRunTask["status"] | undefined
 ): boolean {
@@ -837,38 +763,6 @@ function isTerminalRunStatus(
     status === "skipped"
   );
 }
-
-function isPausedWorkflowStatus(status: string | undefined): boolean {
-  return status === "paused";
-}
-
-function shouldUseManagedAgentWorkflow(
-  params: LocalCompanionStartRunParams,
-  runtime: ChromeDevtoolsMcpRuntime
-): boolean {
-  return (
-    typeof (runtime as { supportsManagedTaskWorkflows?: () => boolean })
-      .supportsManagedTaskWorkflows === "function" &&
-    (runtime as { supportsManagedTaskWorkflows: () => boolean })
-      .supportsManagedTaskWorkflows() &&
-    !isLinkedInProfileConnectGoal(params)
-  );
-}
-
-function shouldUseManagedQueueWorkflow(
-  params: LocalCompanionStartRunParams,
-  runtime: ChromeDevtoolsMcpRuntime
-): boolean {
-  return shouldUseManagedAgentWorkflow(params, runtime);
-}
-
-type ManagedWorkflowTrackingParams = {
-  goal: string;
-  platformHint?: string;
-  pageUrl?: string;
-  pageContext?: string;
-  fieldTarget?: LocalCompanionStartRunParams["fieldTarget"];
-};
 
 function coerceActionFromApproval(
   approval: StoredApprovalRecord
@@ -961,8 +855,7 @@ export class LocalAgentCompanionService {
   private readonly runtime: ChromeDevtoolsMcpRuntime;
   private readonly logger: CompanionLogger;
   private readonly activeExecutions = new Map<string, Promise<void>>();
-  private readonly recoveringManagedUsers = new Set<string>();
-  private recoveringAllManagedRuns = false;
+  private readonly activeRunAbortControllers = new Map<string, AbortController>();
   private runtimeHealth:
     | {
         connected: boolean;
@@ -986,14 +879,13 @@ export class LocalAgentCompanionService {
     this.runtime = runtime ?? new ChromeDevtoolsMcpRuntime({ logger });
     this.logger.event("info", "service", "constructed");
     this.ensureRuntimeHealthFresh(true);
-    this.kickOffManagedWorkflowRecovery();
+    void this.recoverInterruptedRuns();
   }
 
   async getPanelState(args: {
     userScope: string;
     limit?: number;
   }): Promise<LocalCompanionPanelState> {
-    this.kickOffManagedWorkflowRecovery(args.userScope);
     const panelState = await this.store.listPanelState(args.userScope, args.limit ?? 5);
     const runtimeHealth = this.getCachedRuntimeHealth();
     this.ensureRuntimeHealthFresh();
@@ -1042,10 +934,7 @@ export class LocalAgentCompanionService {
       params,
       resumeSourceRun?._id
     );
-    const initialTasks = createInitialRunTasks(
-      params,
-      shouldUseManagedQueueWorkflow(params, this.runtime)
-    );
+    const initialTasks = createInitialRunTasks(params);
     const initialWorkItems = deriveGenericBrowserWorkItems(params);
     const initialTask = initialTasks[0];
     const initialProgress = buildRunProgressPatch(initialTasks, {
@@ -1151,16 +1040,6 @@ export class LocalAgentCompanionService {
       };
     }
 
-    if (run.workflowId || run.workflowRunId) {
-      const cancelled = await this.runtime.cancelAgentTaskWorkflow({
-        workflowId: run.workflowId,
-        runId: run.workflowRunId,
-      });
-      if (!cancelled) {
-        throw new Error("Could not cancel the managed browser workflow.");
-      }
-    }
-
     await this.updatePrimaryRunTask(args.userScope, run._id, {
       status: "skipped",
       latestPageUrl: run.progress?.latestPageUrl ?? run.pageUrl,
@@ -1179,6 +1058,9 @@ export class LocalAgentCompanionService {
       workflowId: run.workflowId,
       workflowRunId: run.workflowRunId,
     });
+
+    this.activeRunAbortControllers.get(run._id)?.abort();
+    this.runtime.killPythonBridge();
 
     return {
       ok: true,
@@ -1210,76 +1092,6 @@ export class LocalAgentCompanionService {
       throw new Error(
         "Missing API key for the configured provider. Add it in Settings to resume Chrome MCP agent tasks."
       );
-    }
-
-    if (
-      sourceRun.status === "paused" &&
-      (sourceRun.workflowId || sourceRun.workflowRunId)
-    ) {
-      const resumePayload = this.buildWorkflowResumeSignalPayload({
-        pageUrl:
-          args.pageUrl ??
-          sourceRun.progress?.latestPageUrl ??
-          sourceRun.pageUrl,
-        pageContext: args.pageContext ?? sourceRun.pageContext,
-        userContext: args.userContext,
-        systemPrompt: args.systemPrompt,
-        fieldTarget: args.fieldTarget ?? sourceRun.fieldTarget,
-        scannedCandidates: args.scannedCandidates,
-        workItems: args.workItems,
-        structured: args.structured,
-        resumeFile: args.resumeFile,
-      });
-      const resumed = await this.runtime.resumeAgentTaskWorkflow({
-        workflowId: sourceRun.workflowId,
-        runId: sourceRun.workflowRunId,
-        signalName: "resume",
-        ...(resumePayload ? { payload: resumePayload } : {}),
-      });
-      if (!resumed) {
-        throw new Error("Could not resume the paused browser workflow.");
-      }
-      await this.store.updateRun(args.userScope, sourceRun._id, {
-        status: "executing",
-        workflowStatus: "running",
-        latestSummary:
-          "Resumed the paused browser workflow in the local Chrome runtime.",
-        completedAt: undefined,
-        lastError: undefined,
-      });
-      await this.updatePrimaryRunTask(args.userScope, sourceRun._id, {
-        status: "running",
-        latestPageUrl:
-          args.pageUrl ??
-          sourceRun.progress?.latestPageUrl ??
-          sourceRun.pageUrl,
-      });
-      this.startManagedWorkflowTracking(
-        args.userScope,
-        sourceRun._id,
-        {
-          goal: sourceRun.goal,
-          platformHint: sourceRun.platformHint,
-          pageUrl:
-            args.pageUrl ??
-            sourceRun.progress?.latestPageUrl ??
-            sourceRun.pageUrl,
-          pageContext: args.pageContext ?? sourceRun.pageContext,
-          fieldTarget: args.fieldTarget ?? sourceRun.fieldTarget,
-        },
-        {
-          workflowId: sourceRun.workflowId ?? sourceRun.workflowRunId ?? sourceRun._id,
-          runId: sourceRun.workflowRunId,
-        }
-      );
-      return {
-        ok: true,
-        status: "executing",
-        runId: sourceRun._id,
-        runtimeId: sourceRun.workflowRunId ?? sourceRun.workflowId,
-        resumedExistingRun: true,
-        sourceRunId: sourceRun._id,
-      };
     }
 
     const resumed = await this.createAndLaunchRun(
@@ -1484,172 +1296,33 @@ export class LocalAgentCompanionService {
     };
   }
 
-  private kickOffManagedWorkflowRecovery(userScope?: string): void {
-    void this.recoverManagedWorkflowTracking(userScope).catch((error) => {
-      this.logger.event("error", "service", "managed_workflow_recovery_failed", {
-        ...(userScope ? { userScope } : {}),
+  private async recoverInterruptedRuns(): Promise<void> {
+    try {
+      const userScopes = await this.store.getAllUserScopes();
+      for (const userScope of userScopes) {
+        const runs = await this.store.listRuns(userScope, 50);
+        for (const run of runs) {
+          if (run.status === "executing" || run.status === "planning") {
+            await this.store.updateRun(userScope, run._id, {
+              status: "failed",
+              lastError: "Run was interrupted when the companion server restarted.",
+              latestSummary: "Run interrupted by server restart.",
+              completedAt: Date.now(),
+              workflowId: undefined,
+              workflowRunId: undefined,
+              workflowStatus: undefined,
+            });
+            this.logger.event("info", "service", "run_marked_interrupted", {
+              runId: run._id,
+              userScope,
+            });
+          }
+        }
+      }
+    } catch (error) {
+      this.logger.event("error", "service", "recover_interrupted_runs_failed", {
         message: error instanceof Error ? error.message : String(error),
       });
-    });
-  }
-
-  private buildManagedWorkflowTrackingParams(
-    run: StoredRunRecord
-  ): ManagedWorkflowTrackingParams {
-    return {
-      goal: run.goal,
-      ...(run.platformHint ? { platformHint: run.platformHint } : {}),
-      ...(run.progress?.latestPageUrl || run.pageUrl
-        ? { pageUrl: run.progress?.latestPageUrl ?? run.pageUrl }
-        : {}),
-      ...(run.pageContext ? { pageContext: run.pageContext } : {}),
-      ...(run.fieldTarget ? { fieldTarget: run.fieldTarget } : {}),
-    };
-  }
-
-  private buildManagedWorkflowTrackingParamsFromStartParams(
-    params: LocalCompanionStartRunParams
-  ): ManagedWorkflowTrackingParams {
-    return {
-      goal: params.goal,
-      ...(params.platformHint ? { platformHint: params.platformHint } : {}),
-      ...(params.pageUrl ? { pageUrl: params.pageUrl } : {}),
-      ...(params.pageContext ? { pageContext: params.pageContext } : {}),
-      ...(params.fieldTarget ? { fieldTarget: params.fieldTarget } : {}),
-    };
-  }
-
-  private async maybeDeriveManagedQueueWorkItems(
-    params: LocalCompanionStartRunParams,
-    resumeContext?: string,
-    siteExperienceContext?: string
-  ): Promise<LocalCompanionBrowserWorkItem[] | null> {
-    if (!shouldUseManagedAgentWorkflow(params, this.runtime)) {
-      return null;
-    }
-
-    const existingItems = deriveGenericBrowserWorkItems(params);
-
-    const discovery = await this.runtime.deriveBrowserWorkItems(
-      this.buildAgentTaskRuntimeArgs(params, resumeContext, siteExperienceContext)
-    );
-    const discoveredItems =
-      Array.isArray(discovery.workItems) && discovery.workItems.length > 1
-        ? discovery.workItems
-        : null;
-
-    this.logger.event("info", "service", "derive_work_items", {
-      goal: params.goal,
-      pageUrl: params.pageUrl,
-      mode: discovery.mode,
-      itemCount: discovery.workItems.length,
-      summary: discovery.summary,
-      fallbackItemCount: existingItems.length,
-    });
-
-    return discoveredItems ?? (existingItems.length > 1 ? existingItems : null);
-  }
-
-  private buildWorkflowResumeSignalPayload(args: {
-    pageUrl?: string;
-    pageContext?: string;
-    userContext?: string;
-    systemPrompt?: string;
-    fieldTarget?: LocalCompanionStartRunParams["fieldTarget"];
-    scannedCandidates?: LocalCompanionStartRunParams["scannedCandidates"];
-    workItems?: LocalCompanionStartRunParams["workItems"];
-    structured?: LocalCompanionStartRunParams["structured"];
-    resumeFile?: LocalCompanionStartRunParams["resumeFile"];
-  }): Record<string, unknown> | undefined {
-    const payload: Record<string, unknown> = {};
-
-    if (args.pageUrl?.trim()) {
-      payload.pageUrl = args.pageUrl.trim();
-    }
-    if (args.pageContext?.trim()) {
-      payload.pageContext = args.pageContext.trim();
-    }
-    if (args.userContext?.trim()) {
-      payload.userContext = args.userContext.trim();
-    }
-    if (args.systemPrompt?.trim()) {
-      payload.systemPrompt = args.systemPrompt.trim();
-    }
-    if (args.fieldTarget) {
-      payload.fieldTarget = args.fieldTarget;
-    }
-    if (args.structured) {
-      payload.structured = args.structured;
-    }
-    if (args.scannedCandidates?.length) {
-      payload.scannedCandidates = args.scannedCandidates;
-    }
-    if (args.workItems?.length) {
-      payload.workItems = args.workItems;
-    }
-    if (args.resumeFile) {
-      payload.resumeFile = args.resumeFile;
-    }
-
-    return Object.keys(payload).length > 0 ? payload : undefined;
-  }
-
-  private async recoverManagedWorkflowTracking(userScope?: string): Promise<void> {
-    if (userScope) {
-      if (this.recoveringManagedUsers.has(userScope)) {
-        return;
-      }
-      this.recoveringManagedUsers.add(userScope);
-    } else if (this.recoveringAllManagedRuns) {
-      return;
-    } else {
-      this.recoveringAllManagedRuns = true;
-    }
-
-    try {
-      const runtimeHealth = await this.ensureRuntimeHealthFresh();
-      if (!runtimeHealth.connected) {
-        return;
-      }
-
-      const runs = userScope
-        ? await this.store.listRuns(userScope, 40)
-        : await this.store.listRecoverableManagedRuns(80);
-
-      for (const run of runs) {
-        if (
-          run.status !== "executing" ||
-          (!run.workflowId && !run.workflowRunId)
-        ) {
-          continue;
-        }
-        const executionKey = `agent:${run._id}`;
-        if (this.activeExecutions.has(executionKey)) {
-          continue;
-        }
-
-        this.logger.event("info", "service", "managed_workflow_recovered", {
-          runId: run._id,
-          workflowId: run.workflowId,
-          workflowRunId: run.workflowRunId,
-          userScope: run.userScope,
-        });
-        this.startManagedWorkflowTracking(
-          run.userScope,
-          run._id,
-          this.buildManagedWorkflowTrackingParams(run),
-          {
-            workflowId: run.workflowId ?? run.workflowRunId ?? run._id,
-            runId: run.workflowRunId,
-          }
-        );
-      }
-    } finally {
-      if (userScope) {
-        this.recoveringManagedUsers.delete(userScope);
-      } else {
-        this.recoveringAllManagedRuns = false;
-      }
     }
   }
 
@@ -1873,56 +1546,11 @@ export class LocalAgentCompanionService {
       if (action.batchType !== "linkedin_connect") {
         throw new Error(`Unsupported task batch type: ${action.batchType}`);
       }
-      if (this.runtime.supportsManagedTaskWorkflows()) {
-        const workflowExecution = await this.runtime.startLinkedInConnectBatchWorkflow({
-          items: action.items,
-          dailyLimit: action.dailyLimit,
-          providerConfig,
-        });
-        await this.store.updateRun(userScope, approval.runId, {
-          status: "executing",
-          workflowId: workflowExecution.workflowId,
-          workflowRunId: workflowExecution.runId,
-          workflowStatus: "scheduled",
-          latestSummary:
-            "LinkedIn connect batch workflow started in the local Chrome runtime.",
-          completedAt: undefined,
-          lastError: undefined,
-        });
-        await this.trackManagedWorkflowExecution(
-          userScope,
-          approval.runId,
-          this.buildManagedWorkflowTrackingParams(run),
-          workflowExecution
-        );
-        const workflowStatus = coerceWorkflowStatus(
-          await this.runtime.getAgentTaskWorkflowStatus({
-            workflowId: workflowExecution.workflowId,
-            runId: workflowExecution.runId,
-          })
-        );
-        const workflowValue = workflowStatus?.value;
-        outcome =
-          workflowValue &&
-          typeof workflowValue.summary === "string" &&
-          workflowValue.summary.trim()
-            ? {
-                summary: workflowValue.summary.trim(),
-                metadata: isPlainObject(workflowValue.metadata)
-                  ? (workflowValue.metadata as Record<string, unknown>)
-                  : undefined,
-              }
-            : {
-                summary:
-                  "LinkedIn connect batch workflow completed in the local Chrome runtime.",
-              };
-      } else {
-        outcome = await this.runtime.executeLinkedInConnectBatch({
-          items: action.items,
-          dailyLimit: action.dailyLimit,
-          providerConfig,
-        });
-      }
+      outcome = await this.runtime.executeLinkedInConnectBatch({
+        items: action.items,
+        dailyLimit: action.dailyLimit,
+        providerConfig,
+      });
       const sentCount =
         typeof outcome.metadata?.sent === "number" ? outcome.metadata.sent : 0;
       const failedCount =
@@ -1968,12 +1596,16 @@ export class LocalAgentCompanionService {
       return;
     }
 
+    const controller = new AbortController();
+    this.activeRunAbortControllers.set(runId, controller);
+
     const execution = this.executeAgentTask(
       userScope,
       runId,
       params,
       resumeContext,
-      siteExperienceContext
+      siteExperienceContext,
+      controller.signal
     )
       .catch(async (error) => {
         const message = error instanceof Error ? error.message : String(error);
@@ -2017,6 +1649,7 @@ export class LocalAgentCompanionService {
       })
       .finally(() => {
         this.activeExecutions.delete(executionKey);
+        this.activeRunAbortControllers.delete(runId);
       });
 
     this.activeExecutions.set(executionKey, execution);
@@ -2025,10 +1658,12 @@ export class LocalAgentCompanionService {
   private buildAgentTaskRuntimeArgs(
     params: LocalCompanionStartRunParams,
     resumeContext?: string,
-    siteExperienceContext?: string
+    siteExperienceContext?: string,
+    runId?: string
   ): {
     providerConfig: LocalCompanionProviderConfig;
     goal: string;
+    runId?: string;
     pageUrl?: string;
     platformHint?: string;
     pageContext?: string;
@@ -2046,6 +1681,7 @@ export class LocalAgentCompanionService {
     return {
       providerConfig: params.providerConfig as LocalCompanionProviderConfig,
       goal: params.goal,
+      ...(runId ? { runId } : {}),
       ...(typeof params.pageUrl === "string" ? { pageUrl: params.pageUrl } : {}),
       ...(typeof params.platformHint === "string"
         ? { platformHint: params.platformHint }
@@ -2076,7 +1712,7 @@ export class LocalAgentCompanionService {
   private async finalizeAgentTaskOutcome(
     userScope: string,
     runId: string,
-    params: ManagedWorkflowTrackingParams,
+    params: { pageUrl?: string },
     outcome: {
       summary: string;
       metadata?: Record<string, unknown>;
@@ -2089,40 +1725,56 @@ export class LocalAgentCompanionService {
           ? outcome.metadata.targetUrl.trim()
           : params.pageUrl;
     const updatedRun = await this.store.getRun(userScope, runId);
-    const runtimeSteps = coerceRuntimeTaskSteps(outcome.metadata);
-    const completedTasks =
-      buildRunTasksFromRuntimeSteps({
-        existingTasks: updatedRun?.tasks,
-        runtimeSteps,
-        finalPageUrl,
-      }) ??
-      updatedRun?.tasks?.map((task, index) => ({
-        ...task,
-        ...(index === 0
-          ? {
-              status: "completed" as const,
-              updatedAt: Date.now(),
-              completedAt: Date.now(),
-              ...(finalPageUrl ? { pageUrl: finalPageUrl } : {}),
-              lastError: undefined,
-              skipReason: undefined,
-            }
-          : task),
-      }));
 
-    if (completedTasks?.length) {
-      await this.store.updateRun(userScope, runId, {
-        tasks: completedTasks,
-        progress: buildRunProgressPatch(completedTasks, {
+    // Plan-managed tasks (ids "task_0", "task_1", …) are updated live via progress
+    // events. Rebuilding them here would race with pending incrementCompletedTasks
+    // mutations and double-count completions. Only touch tasks when there are no
+    // plan-managed tasks or when the metadata provides explicit runtime steps.
+    const hasPlanManagedTasks = updatedRun?.tasks?.some((t) =>
+      /^task_\d+$/.test(t._id)
+    );
+    const runtimeSteps = coerceRuntimeTaskSteps(outcome.metadata);
+
+    if (!hasPlanManagedTasks) {
+      const completedTasks =
+        buildRunTasksFromRuntimeSteps({
+          existingTasks: updatedRun?.tasks,
+          runtimeSteps,
+          finalPageUrl,
+        }) ??
+        updatedRun?.tasks?.map((task, index) => ({
+          ...task,
+          ...(index === 0
+            ? {
+                status: "completed" as const,
+                updatedAt: Date.now(),
+                completedAt: Date.now(),
+                ...(finalPageUrl ? { pageUrl: finalPageUrl } : {}),
+                lastError: undefined,
+                skipReason: undefined,
+              }
+            : task),
+        }));
+
+      if (completedTasks?.length) {
+        await this.store.updateRun(userScope, runId, {
+          tasks: completedTasks,
+          progress: buildRunProgressPatch(completedTasks, {
+            latestPageUrl: finalPageUrl,
+            lastCheckpointAt: Date.now(),
+          }),
+        });
+      } else {
+        await this.updatePrimaryRunTask(userScope, runId, {
+          status: "completed",
           latestPageUrl: finalPageUrl,
-          lastCheckpointAt: Date.now(),
-        }),
-      });
-    } else {
-      await this.updatePrimaryRunTask(userScope, runId, {
-        status: "completed",
+          clearResumeCursor: true,
+        });
+      }
+    } else if (finalPageUrl) {
+      await this.store.updateRunProgress(userScope, runId, {
         latestPageUrl: finalPageUrl,
-        clearResumeCursor: true,
+        lastCheckpointAt: Date.now(),
       });
     }
 
@@ -2142,7 +1794,7 @@ export class LocalAgentCompanionService {
             siteMemory: buildRunSiteMemory({
               run: refreshedRun,
               fallbackPageUrl: finalPageUrl,
-              tasks: completedTasks ?? refreshedRun.tasks,
+              tasks: refreshedRun.tasks,
               workflowName:
                 typeof outcome.metadata?.workflowName === "string"
                   ? outcome.metadata.workflowName
@@ -2171,332 +1823,15 @@ export class LocalAgentCompanionService {
     });
   }
 
-  private async trackManagedWorkflowExecution(
-    userScope: string,
-    runId: string,
-    params: ManagedWorkflowTrackingParams,
-    workflowExecution: {
-      workflowId: string;
-      runId?: string;
-    }
-  ): Promise<void> {
-    const deadline = Date.now() + 10 * 60_000;
-    while (Date.now() < deadline) {
-      const workflowStatus = coerceWorkflowStatus(
-        await this.runtime.getAgentTaskWorkflowStatus({
-          workflowId: workflowExecution.workflowId,
-          runId: workflowExecution.runId,
-        })
-      );
 
-      if (!workflowStatus) {
-        await new Promise((resolve) => setTimeout(resolve, 400));
-        continue;
-      }
-
-      const workflowState = workflowStatus.state;
-      const attemptCount =
-        typeof workflowState?.metadata === "object" &&
-        workflowState.metadata !== null &&
-        typeof (workflowState.metadata as Record<string, unknown>).attempts === "number"
-          ? Number((workflowState.metadata as Record<string, unknown>).attempts)
-          : undefined;
-      const workflowRunStatus =
-        typeof workflowStatus.status === "string" ? workflowStatus.status : undefined;
-      const latestPageUrl =
-        typeof workflowState?.metadata === "object" &&
-        workflowState.metadata !== null &&
-        typeof (workflowState.metadata as Record<string, unknown>).latestPageUrl ===
-          "string"
-          ? String((workflowState.metadata as Record<string, unknown>).latestPageUrl)
-          : params.pageUrl;
-      const workflowPauseReason =
-        typeof workflowState?.metadata === "object" &&
-        workflowState.metadata !== null &&
-        typeof (workflowState.metadata as Record<string, unknown>).pauseReason ===
-          "string"
-          ? String((workflowState.metadata as Record<string, unknown>).pauseReason)
-          : typeof workflowState?.metadata === "object" &&
-              workflowState.metadata !== null &&
-              typeof (workflowState.metadata as Record<string, unknown>).lastError ===
-                "string"
-            ? String((workflowState.metadata as Record<string, unknown>).lastError)
-            : undefined;
-      const workflowStateMetadata =
-        typeof workflowState?.metadata === "object" && workflowState.metadata !== null
-          ? (workflowState.metadata as Record<string, unknown>)
-          : undefined;
-      const workflowStateSteps = coerceRuntimeTaskSteps(workflowStateMetadata);
-      const currentRun = await this.store.getRun(userScope, runId);
-      if (currentRun?.status === "cancelled" && workflowRunStatus !== "cancelled") {
-        await new Promise((resolve) => setTimeout(resolve, 400));
-        continue;
-      }
-
-      await this.store.updateRun(userScope, runId, {
-        workflowId: workflowExecution.workflowId,
-        workflowRunId: workflowExecution.runId,
-        ...(workflowRunStatus ? { workflowStatus: workflowRunStatus } : {}),
-        latestSummary:
-          workflowRunStatus === "running" && attemptCount && attemptCount > 1
-            ? `Workflow retry ${attemptCount} in progress inside the local Chrome runtime.`
-            : workflowRunStatus === "running"
-              ? "Workflow running inside the local Chrome runtime."
-              : workflowRunStatus === "scheduled"
-                ? "Workflow scheduled in the local Chrome runtime."
-                : undefined,
-      });
-      if (workflowStateSteps.length > 0) {
-        const currentRunForSteps = await this.store.getRun(userScope, runId);
-        const updatedTasks = buildRunTasksFromRuntimeSteps({
-          existingTasks: currentRunForSteps?.tasks,
-          runtimeSteps: workflowStateSteps,
-          finalPageUrl: latestPageUrl,
-        });
-        if (updatedTasks) {
-          await this.store.updateRun(userScope, runId, {
-            tasks: updatedTasks,
-            progress: buildRunProgressPatch(updatedTasks, {
-              latestPageUrl,
-              lastCheckpointAt: Date.now(),
-            }),
-          });
-        }
-      }
-      if (isPausedWorkflowStatus(workflowRunStatus)) {
-        await this.updatePrimaryRunTask(userScope, runId, {
-          status: "blocked",
-          latestPageUrl,
-          ...(workflowPauseReason ? { lastError: workflowPauseReason } : {}),
-        });
-        await this.store.updateRun(userScope, runId, {
-          status: "paused",
-          workflowId: workflowExecution.workflowId,
-          workflowRunId: workflowExecution.runId,
-          workflowStatus: workflowRunStatus,
-          latestSummary:
-            workflowPauseReason && workflowPauseReason.trim()
-              ? `Workflow paused inside the local Chrome runtime. ${workflowPauseReason.trim()}`
-              : "Workflow paused inside the local Chrome runtime. Resume to continue from the last checkpoint.",
-          completedAt: undefined,
-        });
-        this.logger.event("info", "service", "agent_task_paused", {
-          runId,
-          workflowId: workflowExecution.workflowId,
-          workflowRunId: workflowExecution.runId,
-        });
-        return;
-      }
-
-      if (attemptCount && attemptCount > 1) {
-        await this.updatePrimaryRunTask(userScope, runId, {
-          status: "retrying",
-          latestPageUrl,
-        });
-      } else if (workflowRunStatus === "running" || workflowRunStatus === "scheduled") {
-        await this.updatePrimaryRunTask(userScope, runId, {
-          status: "running",
-          latestPageUrl,
-        });
-      }
-
-      if (workflowStatus.completed) {
-        const outcomeValue = workflowStatus.value;
-        if (
-          !outcomeValue ||
-          typeof outcomeValue.summary !== "string" ||
-          !outcomeValue.summary.trim()
-        ) {
-          throw new Error("Managed browser workflow completed without a usable result.");
-        }
-        await this.finalizeAgentTaskOutcome(userScope, runId, params, {
-          summary: outcomeValue.summary.trim(),
-          metadata: isPlainObject(outcomeValue.metadata)
-            ? (outcomeValue.metadata as Record<string, unknown>)
-            : undefined,
-        });
-        return;
-      }
-
-      if (
-        !workflowStatus.running &&
-        workflowRunStatus &&
-        workflowRunStatus !== "paused" &&
-        workflowRunStatus !== "scheduled" &&
-        workflowRunStatus !== "running"
-      ) {
-        const currentRun = await this.store.getRun(userScope, runId);
-        if (currentRun?.status === "cancelled" && workflowRunStatus === "cancelled") {
-          this.logger.event("info", "service", "managed_workflow_cancelled", {
-            runId,
-            workflowId: workflowExecution.workflowId,
-            workflowRunId: workflowExecution.runId,
-          });
-          return;
-        }
-        throw new Error(
-          workflowStatus.error || `Managed browser workflow ended with status ${workflowRunStatus}.`
-        );
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 400));
-    }
-
-    throw new Error("Managed browser workflow timed out.");
-  }
-
-  private startManagedWorkflowTracking(
-    userScope: string,
-    runId: string,
-    params: ManagedWorkflowTrackingParams,
-    workflowExecution: {
-      workflowId: string;
-      runId?: string;
-    }
-  ): void {
-    const executionKey = `agent:${runId}`;
-    if (this.activeExecutions.has(executionKey)) {
-      return;
-    }
-
-    const execution = this.trackManagedWorkflowExecution(
-      userScope,
-      runId,
-      params,
-      workflowExecution
-    )
-      .catch(async (error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        const currentRun = await this.store.getRun(userScope, runId);
-        if (currentRun?.status === "cancelled") {
-          this.logger.event("info", "service", "managed_workflow_cancelled", {
-            runId,
-            message,
-          });
-          return;
-        }
-        this.logger.event("error", "service", "agent_task_failed", {
-          runId,
-          message,
-        });
-        await this.updatePrimaryRunTask(userScope, runId, {
-          status: "failed",
-          lastError: message,
-          latestPageUrl: params.pageUrl,
-        });
-        const failedRun = await this.store.getRun(userScope, runId);
-        const progressSummary = summarizeRunProgress(failedRun?.progress);
-        await this.store.updateRun(userScope, runId, {
-          status: "failed",
-          latestSummary: progressSummary ? `${message} · ${progressSummary}` : message,
-          lastError: message,
-          completedAt: Date.now(),
-        });
-      })
-      .finally(() => {
-        this.activeExecutions.delete(executionKey);
-      });
-
-    this.activeExecutions.set(executionKey, execution);
-  }
-
-  private async executeAgentTaskViaManagedWorkflow(
-    userScope: string,
-    runId: string,
-    params: LocalCompanionStartRunParams,
-    resumeContext?: string,
-    siteExperienceContext?: string
-  ): Promise<void> {
-    let runtimeArgs = this.buildAgentTaskRuntimeArgs(
-      params,
-      resumeContext,
-      siteExperienceContext
-    );
-    let useQueueWorkflow = false;
-    try {
-      const discoveredWorkItems = await this.maybeDeriveManagedQueueWorkItems(
-        params,
-        resumeContext,
-        siteExperienceContext
-      );
-      if (discoveredWorkItems && discoveredWorkItems.length > 1) {
-        runtimeArgs = {
-          ...runtimeArgs,
-          workItems: discoveredWorkItems,
-        };
-        useQueueWorkflow = true;
-        const queuedTasks = createRunTasksFromWorkItems(discoveredWorkItems, {
-          firstTaskRunning: true,
-        });
-        await this.store.updateRun(userScope, runId, {
-          workItems: discoveredWorkItems,
-          tasks: queuedTasks,
-          progress: buildRunProgressPatch(queuedTasks, {
-            latestPageUrl:
-              discoveredWorkItems[0]?.pageUrl ?? params.pageUrl,
-            resumeCursor: queuedTasks[0]?._id,
-          }),
-          latestSummary:
-            "Started a durable queue workflow from repeated browser work items.",
-        });
-      }
-    } catch (error) {
-      this.logger.event("warn", "service", "derive_work_items_failed", {
-        runId,
-        goal: params.goal,
-        message: error instanceof Error ? error.message : String(error),
-      });
-      const fallbackWorkItems = deriveGenericBrowserWorkItems(params);
-      if (fallbackWorkItems.length > 1) {
-        runtimeArgs = {
-          ...runtimeArgs,
-          workItems: fallbackWorkItems,
-        };
-        useQueueWorkflow = true;
-        const queuedTasks = createRunTasksFromWorkItems(fallbackWorkItems, {
-          firstTaskRunning: true,
-        });
-        await this.store.updateRun(userScope, runId, {
-          workItems: fallbackWorkItems,
-          tasks: queuedTasks,
-          progress: buildRunProgressPatch(queuedTasks, {
-            latestPageUrl: fallbackWorkItems[0]?.pageUrl ?? params.pageUrl,
-            resumeCursor: queuedTasks[0]?._id,
-          }),
-          latestSummary:
-            "Started a durable queue workflow using fallback browser work items after agent discovery failed.",
-        });
-      }
-    }
-
-    const workflowExecution = useQueueWorkflow
-      ? await this.runtime.startGenericBrowserQueueWorkflow({
-          ...runtimeArgs,
-          workItems: runtimeArgs.workItems ?? deriveGenericBrowserWorkItems(params),
-        })
-      : await this.runtime.startAgentTaskWorkflow(runtimeArgs);
-    await this.store.updateRun(userScope, runId, {
-      workflowId: workflowExecution.workflowId,
-      workflowRunId: workflowExecution.runId,
-      workflowStatus: "scheduled",
-      latestSummary: useQueueWorkflow
-        ? "Generic browser queue workflow started in the local Chrome runtime."
-        : "Generic browser task workflow started in the local Chrome runtime.",
-    });
-    await this.trackManagedWorkflowExecution(
-      userScope,
-      runId,
-      this.buildManagedWorkflowTrackingParamsFromStartParams(params),
-      workflowExecution
-    );
-  }
 
   private async executeAgentTask(
     userScope: string,
     runId: string,
     params: LocalCompanionStartRunParams,
     resumeContext?: string,
-    siteExperienceContext?: string
+    siteExperienceContext?: string,
+    signal?: AbortSignal
   ): Promise<void> {
     if (!params.providerConfig?.apiKey) {
       throw new Error(
@@ -2512,16 +1847,9 @@ export class LocalAgentCompanionService {
       pageUrl: params.pageUrl,
     });
 
-    if (shouldUseManagedAgentWorkflow(params, this.runtime)) {
-      await this.executeAgentTaskViaManagedWorkflow(
-        userScope,
-        runId,
-        params,
-        resumeContext,
-        siteExperienceContext
-      );
-      return;
-    }
+    await this.runtime.registerProgressHandler(runId, (event) => {
+      void this.handleProgressEvent(event, userScope, runId);
+    });
 
     let outcome:
       | {
@@ -2530,15 +1858,9 @@ export class LocalAgentCompanionService {
         }
       | undefined;
     let lastErrorMessage = "";
-    const maxRetries =
-      typeof (this.runtime as { supportsManagedTaskRetries?: () => boolean })
-        .supportsManagedTaskRetries === "function" &&
-      (this.runtime as { supportsManagedTaskRetries: () => boolean })
-        .supportsManagedTaskRetries() &&
-      !isLinkedInProfileConnectGoal(params)
-        ? 0
-        : MAX_AGENT_TASK_RETRIES;
+    const maxRetries = MAX_AGENT_TASK_RETRIES;
 
+    try {
     for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
       await this.updatePrimaryRunTask(userScope, runId, {
         status: attempt === 0 ? "running" : "retrying",
@@ -2559,8 +1881,10 @@ export class LocalAgentCompanionService {
           this.buildAgentTaskRuntimeArgs(
             params,
             resumeContext,
-            siteExperienceContext
-          )
+            siteExperienceContext,
+            runId
+          ),
+          signal
         );
         break;
       } catch (error) {
@@ -2597,6 +1921,120 @@ export class LocalAgentCompanionService {
       throw new Error(lastErrorMessage || "The browser agent did not return an outcome.");
     }
     await this.finalizeAgentTaskOutcome(userScope, runId, params, outcome);
+    } finally {
+      this.runtime.unregisterProgressHandler(runId);
+    }
+  }
+
+  private async handleProgressEvent(
+    event: Record<string, unknown>,
+    userScope: string,
+    runId: string
+  ): Promise<void> {
+    const eventType = typeof event.event === "string" ? event.event : null;
+    if (!eventType) return;
+
+    switch (eventType) {
+      case "planning":
+        await this.store.updateRun(userScope, runId, {
+          status: "planning",
+          latestSummary: "Generating a step-by-step plan…",
+        });
+        break;
+
+      case "plan_ready": {
+        const rawSteps = Array.isArray(event.steps) ? event.steps : [];
+        const now = Date.now();
+        const tasks: LocalCompanionRunTask[] = rawSteps.map((step, i) => ({
+          _id: `task_${i}`,
+          title:
+            typeof (step as Record<string, unknown>).title === "string"
+              ? String((step as Record<string, unknown>).title)
+              : `Step ${i + 1}`,
+          status: "pending" as const,
+          retryCount: 0,
+          createdAt: now,
+          updatedAt: now,
+        }));
+        await this.store.updateRun(userScope, runId, {
+          status: "executing",
+          tasks,
+          progress: {
+            totalTasks: tasks.length,
+            completedTasks: 0,
+            skippedTasks: 0,
+            blockedTasks: 0,
+            retryingTasks: 0,
+            currentTaskIndex: 0,
+          },
+          latestSummary: `Plan ready: ${tasks.length} step${tasks.length !== 1 ? "s" : ""}.`,
+        });
+        break;
+      }
+
+      case "step_started": {
+        const idx = typeof event.index === "number" ? event.index : 0;
+        const stepTitle = typeof event.title === "string" && event.title.trim()
+          ? event.title.trim() : null;
+        await this.store.updateRunTask(userScope, runId, idx, {
+          status: "running",
+          startedAt: Date.now(),
+        });
+        await this.store.updateRunProgress(userScope, runId, { currentTaskIndex: idx });
+        if (stepTitle) {
+          await this.store.updateRun(userScope, runId, {
+            latestSummary: `Step ${idx + 1}: ${stepTitle}`,
+          });
+        }
+        break;
+      }
+
+      case "step_retrying": {
+        const idx = typeof event.index === "number" ? event.index : 0;
+        const attempt = typeof event.attempt === "number" ? event.attempt : 1;
+        const err = typeof event.error === "string" ? event.error : undefined;
+        await this.store.updateRunTask(userScope, runId, idx, {
+          status: "retrying",
+          retryCount: attempt,
+          ...(err ? { lastError: err } : {}),
+        });
+        break;
+      }
+
+      case "step_completed": {
+        const idx = typeof event.index === "number" ? event.index : 0;
+        const summary = typeof event.summary === "string" && event.summary.trim()
+          ? event.summary.trim() : undefined;
+        const verified = typeof event.verified === "boolean" ? event.verified : undefined;
+        const observations = typeof event.observations === "string" && event.observations.trim()
+          ? event.observations.trim()
+          : undefined;
+        await this.store.updateRunTask(userScope, runId, idx, {
+          status: "completed",
+          completedAt: Date.now(),
+          lastError: undefined,
+          ...(summary ? { resultSummary: summary } : {}),
+          ...(verified !== undefined ? { verified } : {}),
+          ...(observations ? { observations } : {}),
+        });
+        await this.store.incrementCompletedTasks(userScope, runId);
+        if (summary) {
+          await this.store.updateRun(userScope, runId, { latestSummary: summary });
+        }
+        break;
+      }
+
+      case "step_failed": {
+        const idx = typeof event.index === "number" ? event.index : 0;
+        const err = typeof event.error === "string" ? event.error : "Step failed";
+        const skipped = event.skipped === true;
+        await this.store.updateRunTask(userScope, runId, idx, {
+          status: skipped ? "skipped" : "failed",
+          lastError: err,
+        });
+        break;
+      }
+    }
   }
 
   private async findResumeSourceRun(

--- a/companion/state-store.ts
+++ b/companion/state-store.ts
@@ -246,6 +246,56 @@ export class CompanionStateStore {
     });
   }
 
+  async getAllUserScopes(): Promise<string[]> {
+    const state = await this.loadState();
+    return Object.keys(state.users);
+  }
+
+  async updateRunTask(
+    userScope: string,
+    runId: string,
+    taskIndex: number,
+    patch: Partial<LocalCompanionRunTask>
+  ): Promise<void> {
+    await this.enqueueMutation(async (state) => {
+      const run = this.requireRun(state, userScope, runId);
+      if (!run.tasks || taskIndex < 0 || taskIndex >= run.tasks.length) {
+        return;
+      }
+      Object.assign(run.tasks[taskIndex], patch, { updatedAt: Date.now() });
+      run.updatedAt = Date.now();
+    });
+  }
+
+  async updateRunProgress(
+    userScope: string,
+    runId: string,
+    progressPatch: Partial<LocalCompanionRunProgress>
+  ): Promise<void> {
+    await this.enqueueMutation(async (state) => {
+      const run = this.requireRun(state, userScope, runId);
+      run.progress = { ...(run.progress ?? {
+        totalTasks: 0,
+        completedTasks: 0,
+        skippedTasks: 0,
+        blockedTasks: 0,
+        retryingTasks: 0,
+        currentTaskIndex: 0,
+      }), ...progressPatch };
+      run.updatedAt = Date.now();
+    });
+  }
+
+  async incrementCompletedTasks(userScope: string, runId: string): Promise<void> {
+    await this.enqueueMutation(async (state) => {
+      const run = this.requireRun(state, userScope, runId);
+      if (run.progress) {
+        run.progress.completedTasks = (run.progress.completedTasks ?? 0) + 1;
+      }
+      run.updatedAt = Date.now();
+    });
+  }
+
   private async loadState(): Promise<StoredState> {
     if (this.cachedState) {
       return this.cachedState;

--- a/companion/temporal_dev_server.py
+++ b/companion/temporal_dev_server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import os
 import signal
 import sys
@@ -37,15 +38,20 @@ async def run_server() -> None:
     db_file = Path(database_path)
     db_file.parent.mkdir(parents=True, exist_ok=True)
 
-    environment = await WorkflowEnvironment.start_local(
-        namespace=namespace,
-        ip=host,
-        port=port,
-        ui=ui_enabled,
-        ui_port=ui_port if ui_enabled else None,
-        dev_server_database_filename=str(db_file),
-        dev_server_log_level=log_level,
-    )
+    start_local_kwargs = {
+        "namespace": namespace,
+        "ip": host,
+        "port": port,
+        "ui": ui_enabled,
+        "dev_server_database_filename": str(db_file),
+        "dev_server_log_level": log_level,
+    }
+    if ui_enabled and "ui_port" in inspect.signature(
+        WorkflowEnvironment.start_local
+    ).parameters:
+        start_local_kwargs["ui_port"] = ui_port
+
+    environment = await WorkflowEnvironment.start_local(**start_local_kwargs)
 
     stop_event = asyncio.Event()
     loop = asyncio.get_running_loop()

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -63,6 +63,7 @@ import {
 import {
   formatSavedSettingsContext,
   formatJobProfileContext,
+  formatUserBasicIdentity,
   shouldIncludeJobApplicationArtifacts,
 } from "../src/lib/agent-user-context.ts";
 import type {
@@ -127,22 +128,29 @@ async function refreshConvexToken(): Promise<boolean> {
   const refreshToken = getStoredConvexRefreshToken(stored);
   if (!refreshToken) return false;
 
-  try {
-    // Clear stale auth before calling the auth endpoint
-    convex.clearAuth();
-    // api.auth.signIn with just a refreshToken performs a silent token refresh
-    const result = await (convex as any).action(api.auth.signIn, { refreshToken });
-    const tokens = result?.tokens as { token: string; refreshToken?: string } | null;
-    if (!tokens?.token) return false;
+  // Retry on transient failures (network errors, SW wake-up latency).
+  // Service workers can be slow to establish connectivity on first wake.
+  const RETRY_DELAYS = [0, 1_500, 4_000];
+  for (const delay of RETRY_DELAYS) {
+    if (delay > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, delay));
+    }
+    try {
+      convex.clearAuth();
+      const result = await (convex as any).action(api.auth.signIn, { refreshToken });
+      const tokens = result?.tokens as { token: string; refreshToken?: string } | null;
+      if (!tokens?.token) return false;
 
-    const updates = buildStoredConvexTokenUpdates(tokens);
-    await chrome.storage.local.set(updates);
-    await syncTaskQueueScope(tokens.token);
-    convex.setAuth(tokens.token);
-    return true;
-  } catch {
-    return false;
+      const updates = buildStoredConvexTokenUpdates(tokens);
+      await chrome.storage.local.set(updates);
+      await syncTaskQueueScope(tokens.token);
+      convex.setAuth(tokens.token);
+      return true;
+    } catch {
+      // swallow and retry
+    }
   }
+  return false;
 }
 
 async function syncTaskQueueScope(token: string | null): Promise<void> {
@@ -196,9 +204,12 @@ async function loadToken() {
     return;
   }
 
-  // Proactively refresh if token is expired or expiring within the next 2 minutes
+  // Proactively refresh if the token is expired or expiring within the next 40 minutes.
+  // The expireContexts alarm fires every 30 min, so a 40-min window guarantees the
+  // alarm always catches the token while it still has time left — avoiding the window
+  // where the background tries to refresh an already-expired token.
   const expiry = parseJwtExpiry(convexToken);
-  if (expiry !== null && Date.now() >= expiry - 2 * 60 * 1000) {
+  if (expiry !== null && Date.now() >= expiry - 40 * 60 * 1000) {
     const refreshed = await refreshConvexToken();
     if (refreshed) return; // setAuth already called inside refreshConvexToken
   }
@@ -321,6 +332,13 @@ async function buildCurrentAgentRuntimeInputs(options?: {
     {}
   )) as BackgroundProfileSnapshot;
   const parts: string[] = [];
+
+  // Always include basic identity (name, email, links) so the agent knows who it's
+  // helping before doing anything — regardless of task type.
+  const userIdentity = formatUserBasicIdentity((profile as any)?.jobProfile);
+  if (userIdentity) {
+    parts.push(userIdentity);
+  }
 
   const formattedSettingsContext = formatSavedSettingsContext(profile?.contextText);
   if (formattedSettingsContext) {

--- a/entrypoints/content/AgentFAB.tsx
+++ b/entrypoints/content/AgentFAB.tsx
@@ -178,7 +178,6 @@ function AgentComposer({
   const currentTask = latestRun ? getAgentRunCurrentTask(latestRun) : null;
   const canCancelLatestRun = Boolean(
     latestRun &&
-      latestRun.workflowId &&
       (latestRun.status === "planning" || latestRun.status === "executing")
   );
   const canResumeLatestRun = Boolean(
@@ -197,9 +196,13 @@ function AgentComposer({
     detail = summary;
   }
 
+  const isAgentActive =
+    latestRun?.status === "executing" || latestRun?.status === "planning";
+
   return createPortal(
     <div
       data-tfa-ui="modal-overlay"
+      aria-hidden={isAgentActive ? "true" : undefined}
       style={{
         position: "fixed",
         inset: 0,
@@ -322,55 +325,153 @@ function AgentComposer({
           </div>
         </div>
 
-        {(progressSummary || currentTask) && (
+        {/* Progress summary — only show the count when task list is visible */}
+        {progressSummary && !(latestRun?.tasks && latestRun.tasks.length > 0) && (
           <div
             style={{
-              padding: "8px 14px",
+              padding: "6px 14px",
               borderBottom: `1px solid ${divider}`,
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              gap: 12,
               background: dark ? "rgba(255,255,255,0.02)" : "rgba(0,0,0,0.015)",
             }}
           >
-            <div style={{ minWidth: 0, flex: 1 }}>
-              {progressSummary && (
-                <div style={{ fontSize: 11, fontWeight: 700, color: text }}>
-                  {progressSummary}
-                </div>
-              )}
-              {currentTask && (
-                <div style={{ minWidth: 0 }}>
-                  <div
+            <div style={{ fontSize: 11, fontWeight: 700, color: text }}>
+              {progressSummary}
+            </div>
+            {currentTask && (
+              <div
+                style={{
+                  fontSize: 10,
+                  color: textSub,
+                  whiteSpace: "nowrap",
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  marginTop: 2,
+                }}
+              >
+                {currentTask.title}
+                {currentTask.retryCount > 0 ? ` · retry ${currentTask.retryCount}` : ""}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Full Task List — Claude-Code style step-by-step plan */}
+        {latestRun?.tasks && latestRun.tasks.length > 0 && (
+          <div
+            style={{
+              padding: "4px 14px 6px",
+              borderBottom: `1px solid ${divider}`,
+              maxHeight: 260,
+              overflowY: "auto",
+            }}
+          >
+            {progressSummary && (
+              <div style={{ fontSize: 10, color: textMuted, paddingTop: 4, paddingBottom: 2, fontWeight: 600 }}>
+                {progressSummary}
+              </div>
+            )}
+            {latestRun.tasks.map((task, i) => {
+              const isActive = task.status === "running" || task.status === "retrying";
+              const icon =
+                task.status === "pending"   ? "○" :
+                task.status === "running"   ? "▶" :
+                task.status === "retrying"  ? "↻" :
+                task.status === "completed" ? "✓" :
+                task.status === "skipped"   ? "⊘" : "✗";
+              const iconColor =
+                task.status === "completed" ? "#16a34a" :
+                task.status === "failed"    ? "#b91c1c" :
+                task.status === "skipped"   ? textMuted :
+                isActive                    ? "#1d4ed8" : textMuted;
+
+              return (
+                <div
+                  key={task._id}
+                  style={{
+                    display: "flex",
+                    alignItems: "flex-start",
+                    gap: 8,
+                    padding: "3px 0",
+                    fontSize: 11,
+                    opacity: task.status === "pending" ? 0.5 : 1,
+                  }}
+                >
+                  <span
                     style={{
-                      fontSize: 10,
-                      color: textSub,
-                      whiteSpace: "nowrap",
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
+                      color: iconColor,
+                      flexShrink: 0,
+                      width: 12,
+                      fontWeight: 700,
+                      paddingTop: 1,
                     }}
                   >
-                    Current task: {currentTask.title}
-                    {currentTask.retryCount > 0 ? ` · retries ${currentTask.retryCount}` : ""}
-                    {currentTask.pageUrl ? ` · ${currentTask.pageUrl}` : ""}
-                  </div>
-                  {currentTask.resultSummary && (
-                    <div
+                    {icon}
+                  </span>
+                  <div style={{ minWidth: 0 }}>
+                    <span
                       style={{
-                        fontSize: 10,
-                        color: textMuted,
+                        color: isActive ? text : task.status === "completed" ? textMuted : text,
+                        fontWeight: isActive ? 600 : 400,
                         whiteSpace: "nowrap",
                         overflow: "hidden",
                         textOverflow: "ellipsis",
+                        display: "block",
                       }}
                     >
-                      {currentTask.resultSummary}
-                    </div>
-                  )}
+                      {task.title}
+                    </span>
+                    {task.status === "running" && (
+                      <span style={{ color: "#1d4ed8", fontSize: 10, display: "block" }}>
+                        running…
+                      </span>
+                    )}
+                    {task.status === "failed" && task.lastError && (
+                      <span
+                        style={{ color: "#b91c1c", fontSize: 10, display: "block" }}
+                      >
+                        {task.lastError.slice(0, 120)}
+                      </span>
+                    )}
+                    {task.status === "retrying" && (
+                      <span
+                        style={{ color: "#d97706", fontSize: 10, display: "block" }}
+                      >
+                        Retrying (attempt {task.retryCount})…
+                      </span>
+                    )}
+                    {task.status === "completed" && task.resultSummary && (
+                      <span
+                        style={{
+                          color: task.verified === false ? "#d97706" : textMuted,
+                          fontSize: 10,
+                          display: "block",
+                          whiteSpace: "nowrap",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                        }}
+                      >
+                        {task.verified === false ? "⚠ unverified · " : ""}{task.resultSummary}
+                      </span>
+                    )}
+                    {task.status === "completed" && task.observations && (
+                      <span
+                        style={{
+                          color: textMuted,
+                          fontSize: 10,
+                          display: "block",
+                          whiteSpace: "nowrap",
+                          overflow: "hidden",
+                          textOverflow: "ellipsis",
+                          fontStyle: "italic",
+                        }}
+                      >
+                        {task.observations.slice(0, 100)}
+                      </span>
+                    )}
+                  </div>
                 </div>
-              )}
-            </div>
+              );
+            })}
           </div>
         )}
 
@@ -548,20 +649,23 @@ export function AgentFAB({
     }
   }, [showToast]);
 
+  const latestRunStatus = latestRun?.status;
+
   useEffect(() => {
     if (!panelOpen) return;
     void refresh();
 
     const intervalId = window.setInterval(() => {
       void refresh();
-    }, getAgentPanelPollMs(document.hidden));
+    }, getAgentPanelPollMs(document.hidden, latestRun));
     const onVisibilityChange = () => void refresh();
     document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       window.clearInterval(intervalId);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [panelOpen, refresh]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [panelOpen, refresh, latestRunStatus]);
 
   useEffect(() => {
     return () => {
@@ -795,6 +899,11 @@ export function AgentFAB({
       <button
         type="button"
         data-tfa-ui="agent-fab"
+        aria-hidden={
+          (latestRun?.status === "executing" || latestRun?.status === "planning")
+            ? "true"
+            : undefined
+        }
         title="Agent Command Center"
         onClick={(event) => {
           event.preventDefault();

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@wxt-dev/module-react": "^1.1.0",
         "convex-test": "^0.0.46",
         "tailwindcss": "^4.0.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.2",
         "vitest": "^4.1.2",
         "wxt": "^0.20.20"
@@ -5887,13 +5888,11 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.7",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-      "integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -8413,8 +8412,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -9276,8 +9273,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@wxt-dev/module-react": "^1.1.0",
     "convex-test": "^0.0.46",
     "tailwindcss": "^4.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.2",
     "wxt": "^0.20.20"

--- a/src/lib/agent-panel-runtime.ts
+++ b/src/lib/agent-panel-runtime.ts
@@ -67,8 +67,10 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-export function getAgentPanelPollMs(hidden: boolean): number {
-  return hidden ? 15_000 : 5_000;
+export function getAgentPanelPollMs(hidden: boolean, activeRun?: AgentPanelRun | null): number {
+  if (hidden) return 15_000;
+  const isActive = activeRun?.status === "executing" || activeRun?.status === "planning";
+  return isActive ? 2_000 : 5_000;
 }
 
 export function normalizeAgentGoal(goal: string, maxLength = 280): string {

--- a/src/lib/agent-user-context.ts
+++ b/src/lib/agent-user-context.ts
@@ -259,6 +259,39 @@ export function shouldIncludeJobApplicationArtifacts(
 }
 
 /**
+ * Extracts a compact identity block (name, email, phone, links) from a saved job profile.
+ * Always included in agent context so the agent knows who it is helping before doing anything.
+ * Kept short deliberately — under 200 chars in typical cases.
+ */
+export function formatUserBasicIdentity(raw: string | null | undefined): string | null {
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (!trimmed) return null;
+  try {
+    const jp = JSON.parse(trimmed);
+    if (typeof jp !== "object" || jp === null) return null;
+    const p = jp.personal ?? {};
+    const l = jp.links ?? {};
+    const parts: string[] = [];
+    const name = [p.firstName, p.lastName].filter(Boolean).join(" ");
+    if (name) {
+      parts.push(`Name: ${name}${p.preferredName ? ` (goes by ${p.preferredName})` : ""}`);
+    }
+    if (p.email) parts.push(`Email: ${p.email}`);
+    if (p.phone) parts.push(`Phone: ${p.phone}`);
+    const loc = [p.city, p.state, p.country].filter(Boolean).join(", ");
+    if (loc) parts.push(`Location: ${loc}`);
+    if (l.linkedin) parts.push(`LinkedIn: ${l.linkedin}`);
+    if (l.github) parts.push(`GitHub: ${l.github}`);
+    if (l.portfolio) parts.push(`Portfolio: ${l.portfolio}`);
+    if (l.website) parts.push(`Website: ${l.website}`);
+    if (parts.length === 0) return null;
+    return `=== User Identity ===\n${parts.join("\n")}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Formats a saved job profile JSON string into a structured block for agent context.
  * The JSON includes personal info, links, work auth, EEO, consents, and resume text.
  */

--- a/src/lib/insert-text.ts
+++ b/src/lib/insert-text.ts
@@ -58,6 +58,10 @@ function _replaceNativeInput(
   el: HTMLInputElement | HTMLTextAreaElement,
   text: string
 ): void {
+  // Focus so React/Vue/Angular event delegation picks up the change (double-click
+  // lands on the icon button, not the field, so the field may not be focused).
+  el.focus();
+
   // Use native setter so React / Vue / Angular pick up the change
   const proto =
     el instanceof HTMLInputElement
@@ -149,9 +153,12 @@ function _replaceContentEditable(el: HTMLElement, text: string): void {
       targetDoc.execCommand("insertHTML", false, html);
   }
 
+  let usedFallback = false;
+
   if (!inserted) {
     // Last-resort fallback: direct DOM manipulation with <p> elements.
     // Quill picks this up via MutationObserver; other editors use it as a failsafe.
+    usedFallback = true;
     target.innerHTML = "";
     for (const para of text.split("\n\n")) {
       const p = targetDoc.createElement("p");
@@ -173,20 +180,37 @@ function _replaceContentEditable(el: HTMLElement, text: string): void {
 
   // Fire events so frameworks (React/Quill/Vue) update their state.
   // Order matches the reference extension: beforeinput → input → change → keydown/up → blur → (50ms) → focus.
-  target.dispatchEvent(new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: text }));
-  target.dispatchEvent(new InputEvent("input", { bubbles: true, cancelable: true, inputType: "insertText", data: text }));
-  target.dispatchEvent(new Event("change", { bubbles: true }));
-  target.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Unidentified" }));
-  target.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true, key: "Unidentified" }));
-  target.dispatchEvent(new Event("blur", { bubbles: true }));
+  //
+  // When the innerHTML fallback was used, MutationObserver callbacks (which editors
+  // like Quill/ProseMirror use to sync their internal model from the DOM) are
+  // microtasks — they fire after the current call stack. Firing `blur` synchronously
+  // would reach the editor's blur handler before MO fires, so the editor would see
+  // an empty model and re-show the placeholder even though the DOM has text.
+  // Wrapping in setTimeout(0) lets all microtasks (MO) run first.
+  const fireEvents = () => {
+    target.dispatchEvent(new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "insertText", data: text }));
+    target.dispatchEvent(new InputEvent("input", { bubbles: true, cancelable: true, inputType: "insertText", data: text }));
+    target.dispatchEvent(new Event("change", { bubbles: true }));
+    target.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "Unidentified" }));
+    target.dispatchEvent(new KeyboardEvent("keyup", { bubbles: true, key: "Unidentified" }));
+    target.dispatchEvent(new Event("blur", { bubbles: true }));
 
-  // Re-focus after a tick and fire LinkedIn's form-level input to enable the Send button
-  setTimeout(() => {
-    try {
-      target.focus();
-      target.dispatchEvent(new Event("focus", { bubbles: true }));
-      const form = target.closest("form, .msg-form");
-      if (form) form.dispatchEvent(new Event("input", { bubbles: true }));
-    } catch { /* ok */ }
-  }, 50);
+    // Re-focus after a tick and fire LinkedIn's form-level input to enable the Send button
+    setTimeout(() => {
+      try {
+        target.focus();
+        target.dispatchEvent(new Event("focus", { bubbles: true }));
+        const form = target.closest("form, .msg-form");
+        if (form) form.dispatchEvent(new Event("input", { bubbles: true }));
+      } catch { /* ok */ }
+    }, 50);
+  };
+
+  if (usedFallback) {
+    // Let MutationObserver callbacks run first so the editor's model is populated
+    // before blur fires (otherwise editors re-show the placeholder).
+    setTimeout(fireEvents, 0);
+  } else {
+    fireEvents();
+  }
 }

--- a/src/lib/local-agent-protocol.ts
+++ b/src/lib/local-agent-protocol.ts
@@ -79,6 +79,8 @@ export interface LocalCompanionRunTask {
   resultSummary?: string;
   lastError?: string;
   skipReason?: string;
+  verified?: boolean;
+  observations?: string;
 }
 
 export interface LocalCompanionRunProgress {

--- a/test/companion/chrome-devtools-mcp-runtime.test.ts
+++ b/test/companion/chrome-devtools-mcp-runtime.test.ts
@@ -43,6 +43,8 @@ function createConnectionMock(
         expect(name).toBe(next.name);
         return next.run(args);
       },
+      registerProgressHandler() {},
+      unregisterProgressHandler() {},
       async close() {
         return;
       },
@@ -189,6 +191,8 @@ describe("ChromeDevtoolsMcpRuntime", () => {
         async executeAgentTask() {
           throw new Error("not used");
         },
+        registerProgressHandler() {},
+        unregisterProgressHandler() {},
         async close() {
           return;
         },
@@ -278,6 +282,8 @@ describe("ChromeDevtoolsMcpRuntime", () => {
         async executeAgentTask() {
           throw new Error("not used");
         },
+        registerProgressHandler() {},
+        unregisterProgressHandler() {},
         async close() {
           return;
         },
@@ -378,6 +384,8 @@ describe("ChromeDevtoolsMcpRuntime", () => {
         async executeAgentTask() {
           throw new Error("not used");
         },
+        registerProgressHandler() {},
+        unregisterProgressHandler() {},
         async close() {
           return;
         },
@@ -455,6 +463,8 @@ describe("ChromeDevtoolsMcpRuntime", () => {
         async executeAgentTask() {
           throw new Error("not used");
         },
+        registerProgressHandler() {},
+        unregisterProgressHandler() {},
         async close() {
           return;
         },
@@ -540,6 +550,8 @@ describe("ChromeDevtoolsMcpRuntime", () => {
             },
           };
         },
+        registerProgressHandler() {},
+        unregisterProgressHandler() {},
         async close() {
           return;
         },
@@ -631,6 +643,8 @@ describe("ChromeDevtoolsMcpRuntime", () => {
         async executeAgentTask() {
           throw new Error("not used");
         },
+        registerProgressHandler() {},
+        unregisterProgressHandler() {},
         async close() {
           return;
         },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
       "https://api.openai.com/*",
       "https://api.anthropic.com/*",
       "https://generativelanguage.googleapis.com/*",
+      "https://aiplatform.googleapis.com/*",
       "https://www.linkedin.com/*",
       "https://mail.google.com/*",
     ],


### PR DESCRIPTION
## Summary

- **Replace Temporal/workflow stack with explicit plan+execute architecture**: Python runtime now runs a planning LLM call (2–6 concrete steps) followed by bounded per-step execution (max 15 iterations each), emitting `plan_ready` / `step_started` / `step_completed` / `step_failed` progress events on stdout
- **Full task list UI (Claude-Code style)**: `AgentFAB` now renders all plan steps with `○▶↻✓⊘✗` status icons, live "running…" sub-text, inline error messages, and a compact progress count — replacing the single opaque "current task" strip
- **Process-level cancellation via AbortController**: Cancel button aborts the in-flight bridge Promise and kills the Python process so Chrome automation stops immediately; new runs start with a fresh bridge
- **Restart recovery**: On server startup, any run stuck in `executing`/`planning` is marked `failed` with "interrupted by server restart" — eliminates the Temporal retry-loop restart bug
- **Dead code removal**: Removed ~1500 lines of Temporal workflow/activity/registration code (`GenericBrowserTaskWorkflowBase`, `LinkedInConnectBatchWorkflowBase`, `BrowserTaskActivities`, etc.) and 6 dead bridge RPC methods
- **Navigation guard against observation loops**: `_extract_step_target_url` pre-navigates to the target site before the LLM runs, preventing Gemini/weak-model infinite snapshot loops; updated execution rules put "NAVIGATE FIRST" as rule 1
- **Extension self-click prevention**: FAB panel and button get `aria-hidden="true"` during active runs so `take_snapshot` excludes the extension overlay from the accessibility tree; system prompt explicitly tells the agent to ignore `data-tfa-ui` elements
- **JSON repair passes**: `_generate_plan` and `_execute_step` now fall back to a finalization LLM call when the primary response is narrative text instead of JSON
- **`finalizeAgentTaskOutcome` race fix**: Detects plan-managed task IDs (`task_0`, `task_1`, …) and skips the task-array rebuild that was racing with pending `incrementCompletedTasks` mutations, causing "2/1 complete" overcounting

## Test plan

- [ ] Start a multi-step task (e.g., "search Amazon for white socks") — plan appears within 3–5 s with 2–6 steps, steps turn green as they complete
- [ ] Click Cancel mid-run — Python process stops, no further Chrome tool calls, new run starts cleanly
- [ ] Kill companion server mid-run, restart — run shows `failed` with "interrupted by server restart", not re-executing
- [ ] Task that requires navigation to a new site — agent navigates immediately without infinite snapshot loop
- [ ] Extension textarea is not interacted with during any run